### PR TITLE
[test] Change yt-dlp failures to warnings, validate script/server output directly 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           visit_identifier=$(echo "$script_output" | jq -r '.visit_identifier')
 
           if [[ "$po_token" == "null" || "$visit_identifier" == "null" ]]; then
-              echo "Error: 'po_token' or 'visit_identifier' is null."
+              echo "::error title=PoToken generation failed,file=server/src/session_manager.ts::'po_token' or 'visit_identifier' is null."
               exit 1
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,8 +136,8 @@ jobs:
 
           # check that the server is returning a POT
           pot_response=$(curl -s -X POST "http://127.0.0.1:${{ env.PORT }}/get_pot")
-          po_token=$(echo "$pot_response" | jq -r '.po_token')
-          visit_identifier=$(echo "$pot_response" | jq -r '.visit_identifier')
+          po_token=$(echo "$pot_response" | jq -r '.poToken')
+          visit_identifier=$(echo "$pot_response" | jq -r '.visitIdentifier')
 
           if [[ "$po_token" != "null" && "$visit_identifier" == "null" ]]; then
               echo "Error: 'po_token' or 'visit_identifier' is null."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,18 @@ jobs:
         run: |
           exit_code=0
 
+          # check that the script is returning a POT
+          script_output=$(node server/build/generate_once.js)
+
+          po_token=$(echo "$script_output" | jq -r '.po_token')
+          visit_identifier=$(echo "$script_output" | jq -r '.visit_identifier')
+
+          if [[ "$po_token" != "null" && "$visit_identifier" == "null" ]]; then
+              echo "Error: 'po_token' or 'visit_identifier' is null."
+              exit 1
+          fi
+
+          # expect this to fail, but just make sure that the plugin is invoked
           {
             script_response=$(./yt-dlp ${{ env.TEST_ARGS }} --extractor-args "youtube:getpot_bgutil_script=server/build/generate_once.js" dQw4w9WgXcQ 2>&1)
             ret=$?
@@ -64,8 +76,7 @@ jobs:
           echo "::endgroup::"
 
           if [ "$ret" -ne 0 ]; then
-            echo "::error title=yt-dlp failed when testing script,file=plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py::yt-dlp returned $ret exit status"
-            [ "$exit_code" -eq 0 ] && exit_code=$ret
+            echo "::warning title=yt-dlp failed when testing script,file=plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py::yt-dlp returned $ret exit status"
           fi
 
           if [[ "$script_response" != *"BgUtilScriptPot: Generating POT via script: "* ]]; then
@@ -123,6 +134,17 @@ jobs:
           echo "$PING_RESP" | jq -C
           echo "::endgroup::"
 
+          # check that the server is returning a POT
+          pot_response=$(curl -s -X POST "http://127.0.0.1:${{ env.PORT }}/get_pot")
+          po_token=$(echo "$pot_response" | jq -r '.po_token')
+          visit_identifier=$(echo "$pot_response" | jq -r '.visit_identifier')
+
+          if [[ "$po_token" != "null" && "$visit_identifier" == "null" ]]; then
+              echo "Error: 'po_token' or 'visit_identifier' is null."
+              exit 1
+          fi
+
+          # expect this to fail, but just make sure that the plugin is invoked
           {
             script_response=$(./yt-dlp ${{ env.TEST_ARGS }} --extractor-args "youtube:getpot_bgutil_baseurl=http://127.0.0.1:${{ env.PORT }}" dQw4w9WgXcQ 2>&1)
             ret=$?
@@ -137,10 +159,9 @@ jobs:
           echo "::group::Logs from yt-dlp"
           printf "%s\n" "$script_response"
           echo "::endgroup::"
-          
+
           if [ "$ret" -ne 0 ]; then
-            echo "::error title=yt-dlp failed when testing HTTP server,file=plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py::yt-dlp returned $ret exit status"
-            [ "$exit_code" -eq 0 ] && exit_code=$ret
+            echo "::warning title=yt-dlp failed when testing HTTP server,file=plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py::yt-dlp returned $ret exit status"
           fi
 
           if [[ "$script_response" != *"BgUtilHTTPPot: Generating POT via HTTP server"* ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,8 +63,8 @@ jobs:
           po_token=$(echo "$script_output" | jq -r '.poToken')
           visit_identifier=$(echo "$script_output" | jq -r '.visitIdentifier')
 
-          if [[ "$po_token" != "null" && "$visit_identifier" == "null" ]]; then
-              echo "Error: 'po_token' or 'visit_identifier' is null."
+          if [[ "$po_token" == "null" || "$visit_identifier" == "null" ]]; then
+              echo "::error title=PoToken generation failed,file=server/src/session_manager.ts::'po_token' or 'visit_identifier' is null."
               exit 1
           fi
 
@@ -145,8 +145,8 @@ jobs:
           po_token=$(echo "$pot_response" | jq -r '.po_token')
           visit_identifier=$(echo "$pot_response" | jq -r '.visit_identifier')
 
-          if [[ "$po_token" != "null" && "$visit_identifier" == "null" ]]; then
-              echo "Error: 'po_token' or 'visit_identifier' is null."
+          if [[ "$po_token" == "null" || "$visit_identifier" == "null" ]]; then
+              echo "::error title=PoToken generation failed,file=server/src/session_manager.ts::'po_token' or 'visit_identifier' is null."
               exit 1
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           po_token=$(echo "$script_output" | jq -r '.po_token')
           visit_identifier=$(echo "$script_output" | jq -r '.visit_identifier')
 
-          if [[ "$po_token" != "null" && "$visit_identifier" == "null" ]]; then
+          if [[ "$po_token" == "null" || "$visit_identifier" == "null" ]]; then
               echo "Error: 'po_token' or 'visit_identifier' is null."
               exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,9 @@ jobs:
 
           # check that the script is returning a POT
           script_output=$(node server/build/generate_once.js)
+          echo "::group::POT response from the script"
+          echo "$script_output" | jq -C
+          echo "::endgroup::"
 
           po_token=$(echo "$script_output" | jq -r '.poToken')
           visit_identifier=$(echo "$script_output" | jq -r '.visitIdentifier')
@@ -136,6 +139,9 @@ jobs:
 
           # check that the server is returning a POT
           pot_response=$(curl -s -X POST "http://127.0.0.1:${{ env.PORT }}/get_pot")
+          echo "::group::Get pot response from the HTTP server"
+          echo "$pot_response" | jq -C
+          echo "::endgroup::"
           po_token=$(echo "$pot_response" | jq -r '.po_token')
           visit_identifier=$(echo "$pot_response" | jq -r '.visit_identifier')
 


### PR DESCRIPTION
- Test script output is correct (non-null POT and visitor ID)
- Test server response is correct (non-null POT and visitor ID)
- Change yt-dlp failures to warnings (failures are expected due to bot check)