### PR TITLE
[client] introduce a base class for the two GetPOTRH

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,9 +82,9 @@ jobs:
             echo "::warning title=yt-dlp failed when testing script,file=plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py::yt-dlp returned $ret exit status"
           fi
 
-          if [[ "$script_response" != *"BgUtilScriptPot: Generating POT via script: "* ]]; then
-            echo "::error title=BgUtilScriptPot was not invoked,file=plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py::\
-          BgUtilScriptPot was not invoked"
+          if [[ "$script_response" != *"BgUtilScript: Generating POT via script: "* ]]; then
+            echo "::error title=BgUtilScript was not invoked,file=plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py::\
+          BgUtilScript was not invoked"
             [ "$exit_code" -eq 0 ] && exit_code=1
           fi
 
@@ -170,9 +170,9 @@ jobs:
             echo "::warning title=yt-dlp failed when testing HTTP server,file=plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py::yt-dlp returned $ret exit status"
           fi
 
-          if [[ "$script_response" != *"BgUtilHTTPPot: Generating POT via HTTP server"* ]]; then
-            echo "::error title=BgUtilHTTPPot was not invoked,file=plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py::\
-          BgUtilHTTPPot was not invoked"
+          if [[ "$script_response" != *"BgUtilHTTP: Generating POT via HTTP server"* ]]; then
+            echo "::error title=BgUtilHTTP was not invoked,file=plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py::\
+          BgUtilHTTP was not invoked"
             [ "$exit_code" -eq 0 ] && exit_code=1
           fi
 

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil.py
@@ -1,1 +1,31 @@
 __version__ = '0.7.3'
+from yt_dlp.networking.common import Features
+from yt_dlp.networking.exceptions import UnsupportedRequest
+from yt_dlp.utils import classproperty, remove_end
+
+try:
+    import yt_dlp_plugins.extractor.getpot as getpot
+except ImportError as e:
+    e.msg += '\nyt-dlp-get-pot is missing! See https://github.com/coletdjnz/yt-dlp-get-pot?tab=readme-ov-file#installing.'
+    raise e
+
+
+class BgUtilBaseGetPOTRH(getpot.GetPOTProvider):
+    _SUPPORTED_CLIENTS = ('web', 'web_safari', 'web_embedded',
+                          'web_music', 'web_creator', 'mweb', 'tv_embedded', 'tv')
+    VERSION = __version__
+    _SUPPORTED_PROXY_SCHEMES = (
+        'http', 'https', 'socks4', 'socks4a', 'socks5', 'socks5h')
+    _SUPPORTED_FEATURES = (Features.NO_PROXY, Features.ALL_PROXY)
+    _GETPOT_TIMEOUT = 20.0
+
+    def warn_and_raise(self, msg, once=True, raise_from=None):
+        self._logger.warning(msg, once=once)
+        raise UnsupportedRequest(msg) from raise_from
+
+    @classproperty
+    def RH_NAME(cls):
+        return cls._PROVIDER_NAME or remove_end(cls.RH_KEY, 'GetPOT')
+
+
+__all__ = [getpot.__name__, '__version__']

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil.py
@@ -17,6 +17,7 @@ class BgUtilBaseGetPOTRH(getpot.GetPOTProvider):
     _SUPPORTED_PROXY_SCHEMES = (
         'http', 'https', 'socks4', 'socks4a', 'socks5', 'socks5h')
     _SUPPORTED_FEATURES = (Features.NO_PROXY, Features.ALL_PROXY)
+    _SUPPORTED_CONTEXTS = ('gvs',)
     _GETPOT_TIMEOUT = 20.0
 
     def warn_and_raise(self, msg, once=True, raise_from=None):

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
@@ -17,7 +17,19 @@ except ImportError:
 else:
     @getpot.register_provider
     class BgUtilHTTPGetPOTRH(BgUtilBaseGetPOTRH):
-        def _validate_get_pot(self, client: str, ydl: YoutubeDL, visitor_data=None, data_sync_id=None, player_url=None, **kwargs):
+        def _validate_get_pot(
+            self,
+            client: str,
+            ydl: YoutubeDL,
+            visitor_data=None,
+            data_sync_id=None,
+            session_index=None,
+            player_url=None,
+            context=None,
+            video_id=None,
+            ytcfg=None,
+            **kwargs,
+        ):
             base_url = ydl.get_info_extractor('Youtube')._configuration_arg(
                 'getpot_bgutil_baseurl', ['http://127.0.0.1:4416'], casesense=True)[0]
             if not data_sync_id and not visitor_data:
@@ -28,7 +40,7 @@ else:
                     f'{base_url}/ping', extensions={'timeout': 5.0}, proxies={'all': None}))
             except Exception as e:
                 self.warn_and_raise(
-                    f'Error reaching GET /ping (caused by {e})', raise_from=e)
+                    f'Error reaching GET /ping (caused by {e.__class__.__name__})', raise_from=e)
             try:
                 response = json.load(response)
             except json.JSONDecodeError as e:
@@ -44,7 +56,19 @@ else:
                     once=True)
             self.base_url = base_url
 
-        def _get_pot(self, client: str, ydl: YoutubeDL, visitor_data=None, data_sync_id=None, player_url=None, **kwargs) -> str:
+        def _get_pot(
+            self,
+            client: str,
+            ydl: YoutubeDL,
+            visitor_data=None,
+            data_sync_id=None,
+            session_index=None,
+            player_url=None,
+            context=None,
+            video_id=None,
+            ytcfg=None,
+            **kwargs,
+        ) -> str:
             self._logger.info('Generating POT via HTTP server')
             if ((proxy := select_proxy('https://jnn-pa.googleapis.com', self.proxies))
                     != select_proxy('https://youtube.com', self.proxies)):
@@ -60,7 +84,7 @@ else:
                         'data_sync_id': data_sync_id,
                         'proxy': proxy,
                     }).encode(), headers={'Content-Type': 'application/json'},
-                    extensions={'timeout': 20.0}, proxies={'all': None}))
+                    extensions={'timeout': self._GETPOT_TIMEOUT}, proxies={'all': None}))
             except Exception as e:
                 raise RequestError(
                     f'Error reaching POST /get_pot (caused by {e!r})') from e

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
@@ -7,90 +7,79 @@ if typing.TYPE_CHECKING:
     from yt_dlp import YoutubeDL
 
 from yt_dlp.networking._helper import select_proxy
-from yt_dlp.networking.common import Features, Request
-from yt_dlp.networking.exceptions import RequestError, UnsupportedRequest
+from yt_dlp.networking.common import Request
+from yt_dlp.networking.exceptions import RequestError
 
 try:
-    from yt_dlp_plugins.extractor.getpot import GetPOTProvider, register_preference, register_provider
-except ImportError as e:
-    e.msg += '\nyt-dlp-get-pot is missing! See https://github.com/coletdjnz/yt-dlp-get-pot?tab=readme-ov-file#installing.'
-    raise e
+    from yt_dlp_plugins.extractor.getpot_bgutil import BgUtilBaseGetPOTRH, getpot
+except ImportError:
+    pass
+else:
+    @getpot.register_provider
+    class BgUtilHTTPGetPOTRH(BgUtilBaseGetPOTRH):
+        def _validate_get_pot(self, client: str, ydl: YoutubeDL, visitor_data=None, data_sync_id=None, player_url=None, **kwargs):
+            base_url = ydl.get_info_extractor('Youtube')._configuration_arg(
+                'getpot_bgutil_baseurl', ['http://127.0.0.1:4416'], casesense=True)[0]
+            if not data_sync_id and not visitor_data:
+                self.warn_and_raise(
+                    'One of [data_sync_id, visitor_data] must be passed')
+            try:
+                response = ydl.urlopen(Request(
+                    f'{base_url}/ping', extensions={'timeout': 5.0}, proxies={'all': None}))
+            except Exception as e:
+                self.warn_and_raise(
+                    f'Error reaching GET /ping (caused by {e})', raise_from=e)
+            try:
+                response = json.load(response)
+            except json.JSONDecodeError as e:
+                self.warn_and_raise(
+                    f'Error parsing response JSON (caused by {e!r})'
+                    f', response: {response.read()}', raise_from=e)
+            if response.get('version') != self.VERSION:
+                self._logger.warning(
+                    f'The provider plugin and the HTTP server are on different versions, '
+                    f'this may cause compatibility issues. '
+                    f'Please ensure they are on the same version. '
+                    f'(plugin: {self.VERSION}, server: {response.get("version", "unknown")})',
+                    once=True)
+            self.base_url = base_url
 
-from yt_dlp_plugins.extractor.getpot_bgutil import __version__
+        def _get_pot(self, client: str, ydl: YoutubeDL, visitor_data=None, data_sync_id=None, player_url=None, **kwargs) -> str:
+            self._logger.info('Generating POT via HTTP server')
+            if ((proxy := select_proxy('https://jnn-pa.googleapis.com', self.proxies))
+                    != select_proxy('https://youtube.com', self.proxies)):
+                self._logger.warning(
+                    'Proxies for https://youtube.com and https://jnn-pa.googleapis.com are different. '
+                    'This is likely to cause subsequent errors.')
 
+            try:
+                response = ydl.urlopen(Request(
+                    f'{self.base_url}/get_pot', data=json.dumps({
+                        'client': client,
+                        'visitor_data': visitor_data,
+                        'data_sync_id': data_sync_id,
+                        'proxy': proxy,
+                    }).encode(), headers={'Content-Type': 'application/json'},
+                    extensions={'timeout': 20.0}, proxies={'all': None}))
+            except Exception as e:
+                raise RequestError(
+                    f'Error reaching POST /get_pot (caused by {e!r})') from e
 
-@register_provider
-class BgUtilHTTPPotProviderRH(GetPOTProvider):
-    _PROVIDER_NAME = 'BgUtilHTTPPot'
-    _SUPPORTED_CLIENTS = ('web', 'web_safari', 'web_embedded',
-                          'web_music', 'web_creator', 'mweb', 'tv_embedded', 'tv')
-    VERSION = __version__
-    _SUPPORTED_PROXY_SCHEMES = (
-        'http', 'https', 'socks4', 'socks4a', 'socks5', 'socks5h')
-    _SUPPORTED_FEATURES = (Features.NO_PROXY, Features.ALL_PROXY)
+            try:
+                response_json = json.load(response)
+            except Exception as e:
+                raise RequestError(
+                    f'Error parsing response JSON (caused by {e!r}). response = {response.read().decode()}') from e
 
-    def _validate_get_pot(self, client: str, ydl: YoutubeDL, visitor_data=None, data_sync_id=None, player_url=None, **kwargs):
-        base_url = ydl.get_info_extractor('Youtube')._configuration_arg(
-            'getpot_bgutil_baseurl', ['http://127.0.0.1:4416'], casesense=True)[0]
-        if not data_sync_id and not visitor_data:
-            raise UnsupportedRequest(
-                'One of [data_sync_id, visitor_data] must be passed')
-        try:
-            response = ydl.urlopen(Request(
-                f'{base_url}/ping', extensions={'timeout': 5.0}, proxies={'all': None}))
-        except Exception as e:
-            raise UnsupportedRequest(
-                f'Error reaching GET /ping (caused by {e!r})') from e
-        try:
-            response = json.load(response)
-        except json.JSONDecodeError as e:
-            raise UnsupportedRequest(
-                f'Error parsing response JSON (caused by {e!r})'
-                f', response: {response.read()}') from e
-        if response.get('version') != self.VERSION:
-            self._logger.warning(
-                f'The provider plugin and the HTTP server are on different versions, '
-                f'this may cause compatibility issues. '
-                f'Please ensure they are on the same version. '
-                f'(plugin: {self.VERSION}, server: {response.get("version", "unknown")})',
-                once=True)
-        self.base_url = base_url
+            if error_msg := response_json.get('error'):
+                raise RequestError(error_msg)
+            if 'po_token' not in response_json:
+                raise RequestError('Server did not respond with a po_token')
 
-    def _get_pot(self, client: str, ydl: YoutubeDL, visitor_data=None, data_sync_id=None, player_url=None, **kwargs) -> str:
-        self._logger.info('Generating POT via HTTP server')
-        if ((proxy := select_proxy('https://jnn-pa.googleapis.com', self.proxies))
-                != select_proxy('https://youtube.com', self.proxies)):
-            self._logger.warning(
-                'Proxies for https://youtube.com and https://jnn-pa.googleapis.com are different. '
-                'This is likely to cause subsequent errors.')
+            return response_json['po_token']
 
-        try:
-            response = ydl.urlopen(Request(
-                f'{self.base_url}/get_pot', data=json.dumps({
-                    'client': client,
-                    'visitor_data': visitor_data,
-                    'data_sync_id': data_sync_id,
-                    'proxy': proxy,
-                }).encode(), headers={'Content-Type': 'application/json'},
-                extensions={'timeout': 20.0}, proxies={'all': None}))
-        except Exception as e:
-            raise RequestError(
-                f'Error reaching POST /get_pot (caused by {e!r})') from e
+    @getpot.register_preference(BgUtilHTTPGetPOTRH)
+    def bgutil_HTTP_getpot_preference(rh, request):
+        return 0
 
-        try:
-            response_json = json.load(response)
-        except Exception as e:
-            raise RequestError(
-                f'Error parsing response JSON (caused by {e!r}). response = {response.read().decode()}') from e
-
-        if error_msg := response_json.get('error'):
-            raise RequestError(error_msg)
-        if 'po_token' not in response_json:
-            raise RequestError('Server did not respond with a po_token')
-
-        return response_json['po_token']
-
-
-@register_preference(BgUtilHTTPPotProviderRH)
-def bgutil_HTTP_getpot_preference(rh, request):
-    return 0
+    __all__ = [BgUtilHTTPGetPOTRH.__class__.__name__, bgutil_HTTP_getpot_preference.__name__]

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py
@@ -64,7 +64,7 @@ else:
             try:
                 stdout, stderr, returncode = Popen.run(
                     command_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
-                    timeout=20.0)
+                    timeout=self._GETPOT_TIMEOUT)
             except subprocess.TimeoutExpired as e:
                 raise RequestError(
                     f'_get_pot_via_script failed: Timeout expired when trying to run script (caused by {e!r})')

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py
@@ -9,105 +9,93 @@ import typing
 if typing.TYPE_CHECKING:
     from yt_dlp import YoutubeDL
 from yt_dlp.networking._helper import select_proxy
-from yt_dlp.networking.common import Features
-from yt_dlp.networking.exceptions import RequestError, UnsupportedRequest
+from yt_dlp.networking.exceptions import RequestError
 from yt_dlp.utils import Popen, classproperty
 
 try:
-    from yt_dlp_plugins.extractor.getpot import GetPOTProvider, register_preference, register_provider
-except ImportError as e:
-    e.msg += '\nyt-dlp-get-pot is missing! See https://github.com/coletdjnz/yt-dlp-get-pot?tab=readme-ov-file#installing.'
-    raise e
+    from yt_dlp_plugins.extractor.getpot_bgutil import BgUtilBaseGetPOTRH, getpot
+except ImportError:
+    pass
+else:
+    @getpot.register_provider
+    class BgUtilScriptGetPOTRH(BgUtilBaseGetPOTRH):
+        @classproperty(cache=True)
+        def _default_script_path(self):
+            home = os.path.expanduser('~')
+            return os.path.join(
+                home, 'bgutil-ytdlp-pot-provider', 'server', 'build', 'generate_once.js')
 
-from yt_dlp_plugins.extractor.getpot_bgutil import __version__
+        def _validate_get_pot(self, client: str, ydl: YoutubeDL, visitor_data=None, data_sync_id=None, player_url=None, **kwargs):
+            script_path = ydl.get_info_extractor('Youtube')._configuration_arg(
+                'getpot_bgutil_script', [self._default_script_path], casesense=True)[0]
+            if not data_sync_id and not visitor_data:
+                self.warn_and_raise(
+                    'One of [data_sync_id, visitor_data] must be passed')
+            if not os.path.isfile(script_path):
+                self.warn_and_raise(
+                    f"Script path doesn't exist: {script_path}")
+            if os.path.basename(script_path) != 'generate_once.js':
+                self.warn_and_raise(
+                    'Incorrect script passed to extractor args. Path to generate_once.js required')
+            if shutil.which('node') is None:
+                self.warn_and_raise('node is not in PATH')
+            self.script_path = script_path
 
-
-@register_provider
-class BgUtilScriptPotProviderRH(GetPOTProvider):
-    _PROVIDER_NAME = 'BgUtilScriptPot'
-    _SUPPORTED_CLIENTS = ('web', 'web_safari', 'web_embedded',
-                          'web_music', 'web_creator', 'mweb', 'tv_embedded', 'tv')
-    VERSION = __version__
-    _SUPPORTED_PROXY_SCHEMES = (
-        'http', 'https', 'socks4', 'socks4a', 'socks5', 'socks5h')
-    _SUPPORTED_FEATURES = (Features.NO_PROXY, Features.ALL_PROXY)
-
-    @classproperty(cache=True)
-    def _default_script_path(self):
-        home = os.path.expanduser('~')
-        return os.path.join(
-            home, 'bgutil-ytdlp-pot-provider', 'server', 'build', 'generate_once.js')
-
-    def _validate_get_pot(self, client: str, ydl: YoutubeDL, visitor_data=None, data_sync_id=None, player_url=None, **kwargs):
-        script_path = ydl.get_info_extractor('Youtube')._configuration_arg(
-            'getpot_bgutil_script', [self._default_script_path], casesense=True)[0]
-        if not data_sync_id and not visitor_data:
-            raise UnsupportedRequest(
-                'One of [data_sync_id, visitor_data] must be passed')
-        if not os.path.isfile(script_path):
-            raise UnsupportedRequest(
-                f"Script path doesn't exist: {script_path}")
-        if os.path.basename(script_path) != 'generate_once.js':
-            raise UnsupportedRequest(
-                'Incorrect script passed to extractor args. Path to generate_once.js required')
-        if shutil.which('node') is None:
-            raise UnsupportedRequest('node is not in PATH')
-        self.script_path = script_path
-
-    def _get_pot(self, client: str, ydl: YoutubeDL, visitor_data=None, data_sync_id=None, player_url=None, **kwargs) -> str:
-        self._logger.info(
-            f'Generating POT via script: {self.script_path}')
-        command_args = ['node', self.script_path]
-        if proxy := select_proxy('https://jnn-pa.googleapis.com', self.proxies):
-            if proxy != select_proxy('https://youtube.com', self.proxies):
-                self._logger.warning(
-                    'Proxies for https://youtube.com and https://jnn-pa.googleapis.com are different. '
-                    'This is likely to cause subsequent errors.')
-            command_args.extend(['-p', proxy])
-        if data_sync_id:
-            command_args.extend(['-d', data_sync_id])
-        elif visitor_data:
-            command_args.extend(['-v', visitor_data])
-        else:
-            raise RequestError(
-                'Unexpected missing visitorData and dataSyncId in _get_pot_via_script')
-        self._logger.debug(
-            f'Executing command to get POT via script: {" ".join(command_args)}')
-
-        try:
-            stdout, stderr, returncode = Popen.run(
-                command_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
-                timeout=20.0)
-        except subprocess.TimeoutExpired as e:
-            raise RequestError(
-                f'_get_pot_via_script failed: Timeout expired when trying to run script (caused by {e!r})')
-        except Exception as e:
-            raise RequestError(
-                f'_get_pot_via_script failed: Unable to run script (caused by {e!r})') from e
-
-        msg = f'stdout:\n{stdout.strip()}'
-        if stderr.strip():  # Empty strings are falsy
-            msg += f'\nstderr:\n{stderr.strip()}'
-        self._logger.debug(msg)
-        if returncode:
-            raise RequestError(
-                f'_get_pot_via_script failed with returncode {returncode}')
-
-        try:
-            # The JSON response is always the last line
-            script_data_resp = json.loads(stdout.splitlines()[-1])
-        except json.JSONDecodeError as e:
-            raise RequestError(
-                f'Error parsing JSON response from _get_pot_via_script (caused by {e!r})') from e
-        else:
+        def _get_pot(self, client: str, ydl: YoutubeDL, visitor_data=None, data_sync_id=None, player_url=None, **kwargs) -> str:
+            self._logger.info(
+                f'Generating POT via script: {self.script_path}')
+            command_args = ['node', self.script_path]
+            if proxy := select_proxy('https://jnn-pa.googleapis.com', self.proxies):
+                if proxy != select_proxy('https://youtube.com', self.proxies):
+                    self._logger.warning(
+                        'Proxies for https://youtube.com and https://jnn-pa.googleapis.com are different. '
+                        'This is likely to cause subsequent errors.')
+                command_args.extend(['-p', proxy])
+            if data_sync_id:
+                command_args.extend(['-d', data_sync_id])
+            elif visitor_data:
+                command_args.extend(['-v', visitor_data])
+            else:
+                raise RequestError(
+                    'Unexpected missing visitorData and dataSyncId in _get_pot_via_script')
             self._logger.debug(
-                f'_get_pot_via_script response = {script_data_resp}')
-        if potoken := script_data_resp.get('poToken'):
-            return potoken
-        else:
-            raise RequestError('The script did not respond with a po_token')
+                f'Executing command to get POT via script: {" ".join(command_args)}')
 
+            try:
+                stdout, stderr, returncode = Popen.run(
+                    command_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+                    timeout=20.0)
+            except subprocess.TimeoutExpired as e:
+                raise RequestError(
+                    f'_get_pot_via_script failed: Timeout expired when trying to run script (caused by {e!r})')
+            except Exception as e:
+                raise RequestError(
+                    f'_get_pot_via_script failed: Unable to run script (caused by {e!r})') from e
 
-@register_preference(BgUtilScriptPotProviderRH)
-def bgutil_script_getpot_preference(rh, request):
-    return 100
+            msg = f'stdout:\n{stdout.strip()}'
+            if stderr.strip():  # Empty strings are falsy
+                msg += f'\nstderr:\n{stderr.strip()}'
+            self._logger.debug(msg)
+            if returncode:
+                raise RequestError(
+                    f'_get_pot_via_script failed with returncode {returncode}')
+
+            try:
+                # The JSON response is always the last line
+                script_data_resp = json.loads(stdout.splitlines()[-1])
+            except json.JSONDecodeError as e:
+                raise RequestError(
+                    f'Error parsing JSON response from _get_pot_via_script (caused by {e!r})') from e
+            else:
+                self._logger.debug(
+                    f'_get_pot_via_script response = {script_data_resp}')
+            if potoken := script_data_resp.get('poToken'):
+                return potoken
+            else:
+                raise RequestError('The script did not respond with a po_token')
+
+    @getpot.register_preference(BgUtilScriptGetPOTRH)
+    def bgutil_script_getpot_preference(rh, request):
+        return 100
+
+    __all__ = [BgUtilScriptGetPOTRH.__class__.__name__, bgutil_script_getpot_preference.__name__]


### PR DESCRIPTION
Previously, importing the plugin without yt-dlp-get-pot prints two stack trace messages because the two files each try to import yt-dlp-get-pot, and both of them failed. This pr addresses this issue and introduces a common base class for the two get-pot request handlers

This pr also updates the action workflows because the classes are renamed