### PR TITLE
Default server verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ node build/main.js
 **Options**
 
 - `-p, --port <PORT>`: The port on which the server listens.
-- `--verbose`: Use verbose logging
 
 **Environment Variables**
 

--- a/server/src/README.md
+++ b/server/src/README.md
@@ -13,7 +13,6 @@ If you are interested in using the script/server standalone for generating your 
     - Returns a JSON:
         - `po_token`: The POT.
 - **GET /ping**: Ping the server. The response includes:
-    - `logging`: Logging verbosity(`normal` or `verbose`).
     - `token_ttl_hours`: The current applied `TOKEN_TTL` value, defaults to 6.
     - `server_uptime`: Uptime of the server process in seconds.
     - `version`: Current server version.

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -4,7 +4,7 @@ import { Command } from "@commander-js/extra-typings";
 import express from "express";
 import bodyParser from "body-parser";
 
-const program = new Command().option("-p, --port <PORT>").option("--verbose");
+const program = new Command().option("-p, --port <PORT>");
 
 program.parse();
 const options = program.opts();
@@ -21,7 +21,7 @@ httpServer.listen({
 
 console.log(`Started POT server on port ${PORT_NUMBER}`);
 
-const sessionManager = new SessionManager(options.verbose || true);
+const sessionManager = new SessionManager();
 httpServer.post("/get_pot", async (request, response) => {
     const proxy: string = request.body.proxy;
     const contentBinding = (request.body.content_binding ||
@@ -61,7 +61,6 @@ httpServer.post("/invalidate_caches", async (request, response) => {
 
 httpServer.get("/ping", async (request, response) => {
     response.send({
-        logging: options.verbose ? "verbose" : "normal",
         token_ttl_hours: process.env.TOKEN_TTL || 6,
         server_uptime: process.uptime(),
         version: VERSION,

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -21,7 +21,7 @@ httpServer.listen({
 
 console.log(`Started POT server on port ${PORT_NUMBER}`);
 
-const sessionManager = new SessionManager(options.verbose || false);
+const sessionManager = new SessionManager(options.verbose || true);
 httpServer.post("/get_pot", async (request, response) => {
     const proxy: string = request.body.proxy;
     const contentBinding = (request.body.content_binding ||


### PR DESCRIPTION
We added verbosity option to limit the output from `script`, in-case any consumers relied on the stdout. This is not true for the server method, where we should log as much as possible