### PR TITLE
fix: unsafe import of select_proxy

### DIFF
--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil.py
@@ -6,8 +6,12 @@ import typing
 
 if typing.TYPE_CHECKING:
     from yt_dlp import YoutubeDL
-# NOTE: this is internal only and may be moved in the future
-from yt_dlp.networking._helper import select_proxy
+
+try:
+    from yt_dlp.networking._helper import select_proxy
+except ImportError:
+    from yt_dlp.utils.networking import select_proxy
+
 from yt_dlp.networking.common import Features
 from yt_dlp.networking.exceptions import UnsupportedRequest
 from yt_dlp.utils import classproperty, remove_end


### PR DESCRIPTION
`yt_dlp.networking._helper. select_proxy` is internal and will not be available after https://github.com/yt-dlp/yt-dlp/pull/12840 is merged. This adds a fallback to try use the new select_proxy import until #77 is merged.

Once https://github.com/yt-dlp/yt-dlp/pull/12840 is merged, I presume there will be a period where yt-dlp nightly has the new framework and this plugin is still using GetPOT, in which this import will break.