### PR TITLE
Deprecate visitor data and data sync id

### DIFF
--- a/server/src/generate_once.ts
+++ b/server/src/generate_once.ts
@@ -30,8 +30,8 @@ const CACHE_PATH = path.resolve(cachedir, "cache.json");
 
 const program = new Command()
     .option("-c, --content-binding <content-binding>")
-    .option("-v, --visitor-data <visitordata>")
-    .option("-d, --data-sync-id <data-sync-id>")
+    .option("-v, --visitor-data <visitordata>") // to be removed in a future version
+    .option("-d, --data-sync-id <data-sync-id>") // to be removed in a future version
     .option("-p, --proxy <proxy-all>")
     .option("-b, --bypass-cache")
     .option("--version")
@@ -56,14 +56,18 @@ const options = program.opts();
     }
     const contentBinding =
         options.contentBinding || options.dataSyncId || options.visitorData;
-    if (options.dataSyncId)
-        console.warn(
+    if (options.dataSyncId) {
+        console.error(
             "Data sync id is deprecated, use --content-binding instead",
         );
-    if (options.visitorData)
-        console.warn(
+        process.exit(1);
+    }
+    if (options.visitorData) {
+        console.error(
             "Visitor data is deprecated, use --content-binding instead",
         );
+        process.exit(1);
+    }
 
     const proxy = options.proxy || "";
     const verbose = options.verbose || false;

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -28,10 +28,19 @@ httpServer.post("/get_pot", async (request, response) => {
         request.body.content_binding ||
         request.body.data_sync_id ||
         request.body.visitor_data;
-    if (request.body.data_sync_id)
-        console.warn("data_sync_id is deprecated, use content_binding instead");
-    if (request.body.visitor_data)
-        console.warn("visitor_data is deprecated, use content_binding instead");
+    if (request.body.data_sync_id) {
+        console.error(
+            "data_sync_id is deprecated, use content_binding instead",
+        );
+        process.exit(1);
+    }
+
+    if (request.body.visitor_data) {
+        console.error(
+            "visitor_data is deprecated, use content_binding instead",
+        );
+        process.exit(1);
+    }
 
     try {
         const sessionData = await sessionManager.generatePoToken(


### PR DESCRIPTION
Will remove the code references 1-2 releases after this one to ensure people have time to see the error message and migrate to content-binding. 