### PR TITLE
Hardcode server version into code

### DIFF
--- a/server/src/version.ts
+++ b/server/src/version.ts
@@ -1,8 +1,1 @@
-import * as fs from "fs";
-import * as path from "path";
-
-const packageJson = fs.readFileSync(
-    path.resolve(__dirname, "..", "package.json"),
-    "utf8",
-);
-export const VERSION = JSON.parse(packageJson).version;
+export const VERSION = "1.0.0";


### PR DESCRIPTION
Reading version from package.json can mismatch with the transpiled code, if new code is pulled but not re-transpiled.