### PR TITLE
Support request source address and tls verification options

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ npx tsc
 
 #### PyPI:
 
+If yt-dlp is installed through `pip` or `pipx`, you can install the plugin with the following:
+
 ```shell
 python3 -m pip install -U bgutil-ytdlp-pot-provider
 ```

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil.py
@@ -18,6 +18,8 @@ class BgUtilPTPBase(provider.PoTokenProvider, abc.ABC):
         provider.ExternalRequestFeature.PROXY_SCHEME_SOCKS4A,
         provider.ExternalRequestFeature.PROXY_SCHEME_SOCKS5,
         provider.ExternalRequestFeature.PROXY_SCHEME_SOCKS5H,
+        provider.ExternalRequestFeature.SOURCE_ADDRESS,
+        provider.ExternalRequestFeature.DISABLE_TLS_VERIFICATION,
     )
     _SUPPORTED_CONTEXTS = (
         provider.PoTokenContext.GVS,

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
@@ -119,7 +119,7 @@ class BgUtilHTTPPTP(BgUtilPTPBase):
                         'proxy': request.request_proxy,
                         'bypass_cache': request.bypass_cache,
                         'source_address': request.request_source_address,
-                        'verify_tls': request.request_verify_tls,
+                        'disable_tls_verification': not request.request_verify_tls,
                     }).encode(), headers={'Content-Type': 'application/json'},
                     extensions={'timeout': self._GETPOT_TIMEOUT}, proxies={'all': None}),
                 note=f'Generating a {request.context.value} PO Token for '

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
@@ -118,6 +118,8 @@ class BgUtilHTTPPTP(BgUtilPTPBase):
                         'content_binding': get_webpo_content_binding(request)[0],
                         'proxy': request.request_proxy,
                         'bypass_cache': request.bypass_cache,
+                        'source_address': request.request_source_address,
+                        'verify_tls': request.request_verify_tls,
                     }).encode(), headers={'Content-Type': 'application/json'},
                     extensions={'timeout': self._GETPOT_TIMEOUT}, proxies={'all': None}),
                 note=f'Generating a {request.context.value} PO Token for '

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py
@@ -132,6 +132,11 @@ class BgUtilScriptPTP(BgUtilPTPBase):
         command_args.extend(['-c', get_webpo_content_binding(request)[0]])
         if request.bypass_cache:
             command_args.append('--bypass-cache')
+        if request.request_source_address:
+            command_args.append(
+                ['--source-address', request.request_source_address])
+        if request.request_verify_tls is False:
+            command_args.append('--disable-tls-verification')
 
         self.logger.info(
             f'Generating a {request.context.value} PO Token for '

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py
@@ -133,7 +133,7 @@ class BgUtilScriptPTP(BgUtilPTPBase):
         if request.bypass_cache:
             command_args.append('--bypass-cache')
         if request.request_source_address:
-            command_args.append(
+            command_args.extend(
                 ['--source-address', request.request_source_address])
         if request.request_verify_tls is False:
             command_args.append('--disable-tls-verification')

--- a/server/package.json
+++ b/server/package.json
@@ -24,8 +24,8 @@
         "commander": "github:tj/commander.js.git#develop",
         "express": "^4.21.2",
         "https-proxy-agent": "^7.0.6",
+        "https-socks-proxy": "^2.2.0",
         "jsdom": "^25.0.1",
-        "socks-proxy-agent": "^8.0.5",
         "youtubei.js": "^13.4.0"
     },
     "devDependencies": {

--- a/server/src/generate_once.ts
+++ b/server/src/generate_once.ts
@@ -34,6 +34,8 @@ const program = new Command()
     .option("-d, --data-sync-id <data-sync-id>") // to be removed in a future version
     .option("-p, --proxy <proxy-all>")
     .option("-b, --bypass-cache")
+    .option("-s, --source-address <source-address>")
+    .option("--disable-tls-verification")
     .option("--version")
     .option("--verbose")
     .exitOverride();
@@ -104,6 +106,8 @@ const options = program.opts();
             contentBinding,
             proxy,
             options.bypassCache || false,
+            options.sourceAddress,
+            options.disableTlsVerification === true ? false : true,
         );
 
         try {

--- a/server/src/generate_once.ts
+++ b/server/src/generate_once.ts
@@ -107,7 +107,7 @@ const options = program.opts();
             proxy,
             options.bypassCache || false,
             options.sourceAddress,
-            options.disableTlsVerification === true ? false : true,
+            options.disableTlsVerification || false,
         );
 
         try {

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -38,7 +38,8 @@ httpServer.post("/get_pot", async (request, response) => {
     const proxy: string = request.body.proxy;
     const bypassCache: boolean = request.body.bypass_cache || false;
     const sourceAddress: string | undefined = request.body.source_address;
-    const verifyTls: boolean = request.body.verify_tls;
+    const disableTlsVerification: boolean =
+        request.body.disable_tls_verification;
 
     try {
         const sessionData = await sessionManager.generatePoToken(
@@ -46,7 +47,7 @@ httpServer.post("/get_pot", async (request, response) => {
             proxy,
             bypassCache,
             sourceAddress,
-            verifyTls,
+            disableTlsVerification,
         );
 
         response.send(sessionData);

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -36,13 +36,17 @@ httpServer.post("/get_pot", async (request, response) => {
     }
     const contentBinding: string | undefined = request.body.content_binding;
     const proxy: string = request.body.proxy;
-    const bypassCache = request.body.bypass_cache || false;
+    const bypassCache: boolean = request.body.bypass_cache || false;
+    const sourceAddress: string | undefined = request.body.source_address;
+    const verifyTls: boolean = request.body.verify_tls;
 
     try {
         const sessionData = await sessionManager.generatePoToken(
             contentBinding,
             proxy,
             bypassCache,
+            sourceAddress,
+            verifyTls,
         );
 
         response.send(sessionData);

--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -3,7 +3,7 @@ import { JSDOM } from "jsdom";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import axios from "axios";
 import { Agent } from "https";
-import { SocksProxyAgent } from "socks-proxy-agent";
+import { SocksProxyAgent } from "https-socks-proxy";
 import { Innertube } from "youtubei.js";
 interface YoutubeSessionData {
     poToken: string;
@@ -135,11 +135,13 @@ export class SessionManager {
             case "socks4":
             case "socks4a":
             case "socks5":
-            case "socks5h":
+            case "socks5h": {
                 this.logger.log(`Using SOCKS proxy: ${loggedProxy}`);
-                return new SocksProxyAgent(proxy, {
-                    localAddress: sourceAddress,
-                });
+                const agent = new SocksProxyAgent(proxy);
+                agent.options.localAddress = sourceAddress;
+                agent.options.rejectUnauthorized = !disableTlsVerification;
+                return agent;
+            }
             default:
                 this.logger.warn(`Unsupported proxy protocol: ${loggedProxy}`);
                 return undefined;

--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -91,7 +91,11 @@ export class SessionManager {
         return visitorData;
     }
 
-    getProxyDispatcher(proxy: string | undefined): Agent | undefined {
+    getProxyDispatcher(
+        proxy: string | undefined,
+        sourceAddress: string | undefined,
+        verifyTls: boolean = true,
+    ): Agent | undefined {
         if (!proxy) return undefined;
         let protocol: string;
         try {
@@ -119,14 +123,19 @@ export class SessionManager {
             case "http":
             case "https":
                 this.logger.log(`Using HTTP/HTTPS proxy: ${loggedProxy}`);
-                return new HttpsProxyAgent(proxy);
+                return new HttpsProxyAgent(proxy, {
+                    rejectUnauthorized: verifyTls,
+                    localAddress: sourceAddress,
+                });
             case "socks":
             case "socks4":
             case "socks4a":
             case "socks5":
             case "socks5h":
                 this.logger.log(`Using SOCKS proxy: ${loggedProxy}`);
-                return new SocksProxyAgent(proxy);
+                return new SocksProxyAgent(proxy, {
+                    localAddress: sourceAddress,
+                });
             default:
                 this.logger.warn(`Unsupported proxy protocol: ${loggedProxy}`);
                 return undefined;
@@ -137,6 +146,8 @@ export class SessionManager {
         contentBinding: string | undefined,
         proxy: string = "",
         bypassCache = false,
+        sourceAddress: string | undefined = undefined,
+        verifyTls: boolean = true,
     ): Promise<YoutubeSessionData> {
         if (!contentBinding) {
             this.logger.error(
@@ -174,12 +185,18 @@ export class SessionManager {
 
         let dispatcher: Agent | undefined;
         if (proxy) {
-            dispatcher = this.getProxyDispatcher(proxy);
+            dispatcher = this.getProxyDispatcher(
+                proxy,
+                sourceAddress,
+                verifyTls,
+            );
         } else {
             dispatcher = this.getProxyDispatcher(
                 process.env.HTTPS_PROXY ||
                     process.env.HTTP_PROXY ||
                     process.env.ALL_PROXY,
+                sourceAddress,
+                verifyTls,
             );
         }
 

--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -5,7 +5,7 @@ import axios from "axios";
 import { Agent } from "https";
 import { SocksProxyAgent } from "socks-proxy-agent";
 import { Innertube } from "youtubei.js";
-
+import * as https from "https";
 interface YoutubeSessionData {
     poToken: string;
     contentBinding: string;
@@ -96,7 +96,12 @@ export class SessionManager {
         sourceAddress: string | undefined,
         verifyTls: boolean = true,
     ): Agent | undefined {
-        if (!proxy) return undefined;
+        if (!proxy) {
+            return new https.Agent({
+                localAddress: sourceAddress,
+                rejectUnauthorized: verifyTls,
+            });
+        }
         let protocol: string;
         try {
             const parsedUrl = new URL(proxy);

--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -5,7 +5,6 @@ import axios from "axios";
 import { Agent } from "https";
 import { SocksProxyAgent } from "socks-proxy-agent";
 import { Innertube } from "youtubei.js";
-import * as https from "https";
 interface YoutubeSessionData {
     poToken: string;
     contentBinding: string;
@@ -97,7 +96,7 @@ export class SessionManager {
         disableTlsVerification: boolean = false,
     ): Agent | undefined {
         if (!proxy) {
-            return new https.Agent({
+            return new Agent({
                 localAddress: sourceAddress,
                 rejectUnauthorized: !disableTlsVerification,
             });

--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -94,12 +94,12 @@ export class SessionManager {
     getProxyDispatcher(
         proxy: string | undefined,
         sourceAddress: string | undefined,
-        verifyTls: boolean = true,
+        disableTlsVerification: boolean = false,
     ): Agent | undefined {
         if (!proxy) {
             return new https.Agent({
                 localAddress: sourceAddress,
-                rejectUnauthorized: verifyTls,
+                rejectUnauthorized: !disableTlsVerification,
             });
         }
         let protocol: string;
@@ -129,7 +129,7 @@ export class SessionManager {
             case "https":
                 this.logger.log(`Using HTTP/HTTPS proxy: ${loggedProxy}`);
                 return new HttpsProxyAgent(proxy, {
-                    rejectUnauthorized: verifyTls,
+                    rejectUnauthorized: !disableTlsVerification,
                     localAddress: sourceAddress,
                 });
             case "socks":
@@ -152,7 +152,7 @@ export class SessionManager {
         proxy: string = "",
         bypassCache = false,
         sourceAddress: string | undefined = undefined,
-        verifyTls: boolean = true,
+        disableTlsVerification: boolean = false,
     ): Promise<YoutubeSessionData> {
         if (!contentBinding) {
             this.logger.error(
@@ -193,7 +193,7 @@ export class SessionManager {
             dispatcher = this.getProxyDispatcher(
                 proxy,
                 sourceAddress,
-                verifyTls,
+                disableTlsVerification,
             );
         } else {
             dispatcher = this.getProxyDispatcher(
@@ -201,7 +201,7 @@ export class SessionManager {
                     process.env.HTTP_PROXY ||
                     process.env.ALL_PROXY,
                 sourceAddress,
-                verifyTls,
+                disableTlsVerification,
             );
         }
 

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -428,6 +428,13 @@ acorn@^8.11.0, acorn@^8.14.0, acorn@^8.4.1, acorn@^8.8.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.1.tgz#721d5dc10f7d5b5609a891773d47731796935dfb"
   integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 agent-base@^7.1.0, agent-base@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.3.tgz#29435eb821bc4194633a5b89e5bc4703bafc25a1"
@@ -1132,6 +1139,15 @@ https-proxy-agent@^7.0.5, https-proxy-agent@^7.0.6:
     agent-base "^7.1.2"
     debug "4"
 
+https-socks-proxy@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/https-socks-proxy/-/https-socks-proxy-2.2.0.tgz#631586c74a5a5ff68c02a8125a8220b6ea979e53"
+  integrity sha512-zZAfdb8uoYcFUbH636xjAIg5foybJ4DZC7pJ1A1vLOmVTXedlYDDg5LazqO6cIi+jZNWX5k6wholMB5WQqJm2A==
+  dependencies:
+    agent-base "6"
+    debug "4"
+    socks "^2.3.3"
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -1675,16 +1691,7 @@ smart-buffer@^4.2.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-socks-proxy-agent@^8.0.5:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz#b9cdb4e7e998509d7659d689ce7697ac21645bee"
-  integrity sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==
-  dependencies:
-    agent-base "^7.1.2"
-    debug "^4.3.4"
-    socks "^2.8.3"
-
-socks@^2.8.3:
+socks@^2.3.3:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.4.tgz#07109755cdd4da03269bda4725baa061ab56d5cc"
   integrity sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==


### PR DESCRIPTION
Fixes issue where plugin isn't invoked when passing `-4`, or any other options changing source address. #94