### PR TITLE
Use `po_token` from older servers

### DIFF
--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
@@ -137,11 +137,17 @@ class BgUtilHTTPPTP(BgUtilPTPBase):
 
         if error_msg := response_json.get('error'):
             raise PoTokenProviderError(error_msg)
-        if 'poToken' not in response_json:
+        po_token = None
+        if 'poToken' in response_json:
+            po_token = response_json['poToken']
+        elif 'po_token' in response_json:
+            # Keep support for older servers,
+            # instead of instructing users to report an issue.
+            po_token = response_json['po_token']
+        if po_token is None:
             raise PoTokenProviderError(
                 f'Server did not respond with a poToken. Received response: {json.dumps(response_json)}')
 
-        po_token = response_json['poToken']
         self.logger.trace(f'Generated POT: {po_token}')
         return PoTokenResponse(po_token=po_token)
 


### PR DESCRIPTION
I had left an old server container running and upgraded to a 1.0+ plugin.

This is the error that I received in that situation:
```
[youtube] [pot] Error fetching PO Token from "bgutil:http" provider: PoTokenProviderError('Server did not respond with a poToken. Received response: {"po_token": "[snipped]=", "visit_identifier": "[snipped]%3D%3D", "generated_at": "2025-06-10T07:53:00.966Z"}'); please report this issue to the provider developer at  https://github.com/Brainicism/bgutil-ytdlp-pot-provider/issues  .
```

Since it was creating `po_token` and using it happily before I upgraded the plugin, I figured that looking for the old key is a better solution than showing instructions to report a new issue.