### PR TITLE
chore: update python version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache: "pip"
 
       - name: Install Hatch
         run: pipx install hatch
@@ -97,7 +96,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache: "pip"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,8 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.x"
+          cache: "pip"
 
       - name: Install Hatch
         run: pipx install hatch
@@ -95,7 +96,8 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.x"
+          cache: "pip"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9" # keep in sync with yt-dlp's python requirement
+          python-version: "3.x" # keep in sync with yt-dlp's python requirement
       - name: Download yt-dlp
         run: curl -L https://github.com/yt-dlp/yt-dlp-nightly-builds/releases/latest/download/yt-dlp -o yt-dlp && chmod +x ./yt-dlp
       - name: Install and build server dependencies
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9" # keep in sync with yt-dlp's python requirement
+          python-version: "3.x" # keep in sync with yt-dlp's python requirement
       - name: Download yt-dlp
         run: curl -L https://github.com/yt-dlp/yt-dlp-nightly-builds/releases/latest/download/yt-dlp -o yt-dlp && chmod +x ./yt-dlp
       - name: Install plugin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x" # keep in sync with yt-dlp's python requirement
-          cache: "pip"
       - name: Download yt-dlp
         run: curl -L https://github.com/yt-dlp/yt-dlp-nightly-builds/releases/latest/download/yt-dlp -o yt-dlp && chmod +x ./yt-dlp
       - name: Install and build server dependencies
@@ -119,7 +118,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x" # keep in sync with yt-dlp's python requirement
-          cache: "pip"
       - name: Download yt-dlp
         run: curl -L https://github.com/yt-dlp/yt-dlp-nightly-builds/releases/latest/download/yt-dlp -o yt-dlp && chmod +x ./yt-dlp
       - name: Install plugin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x" # keep in sync with yt-dlp's python requirement
+          cache: "pip"
       - name: Download yt-dlp
         run: curl -L https://github.com/yt-dlp/yt-dlp-nightly-builds/releases/latest/download/yt-dlp -o yt-dlp && chmod +x ./yt-dlp
       - name: Install and build server dependencies
@@ -118,6 +119,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x" # keep in sync with yt-dlp's python requirement
+          cache: "pip"
       - name: Download yt-dlp
         run: curl -L https://github.com/yt-dlp/yt-dlp-nightly-builds/releases/latest/download/yt-dlp -o yt-dlp && chmod +x ./yt-dlp
       - name: Install plugin


### PR DESCRIPTION
Address yt-dlp warning:

```
Support for Python version 3.9 has been deprecated. Please update to Python 3.10 or above
```