### PR TITLE
Update commander.js to release version

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,7 +20,7 @@
                 "youtubei.js": "^15.0.1"
             },
             "devDependencies": {
-                "@commander-js/extra-typings": "github:commander-js/extra-typings.git#develop",
+                "@commander-js/extra-typings": "^14.0.0",
                 "@eslint/js": "^9.32.0",
                 "@types/body-parser": "^1.19.6",
                 "@types/express": "^5.0.3",

--- a/server/package.json
+++ b/server/package.json
@@ -30,7 +30,7 @@
         "youtubei.js": "^15.0.1"
     },
     "devDependencies": {
-        "@commander-js/extra-typings": "github:commander-js/extra-typings.git#develop",
+        "@commander-js/extra-typings": "^14.0.0",
         "@eslint/js": "^9.32.0",
         "@types/body-parser": "^1.19.6",
         "@types/express": "^5.0.3",


### PR DESCRIPTION
Ambient module support is in 14.0.0 (https://github.com/commander-js/extra-typings/pull/92)

Fixes #129 maybe