### PR TITLE
Listen on [::] instead of 0.0.0.0, set IP family

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -15,7 +15,7 @@ httpServer.use(express.urlencoded({ extended: true }));
 
 httpServer.listen(
     {
-        host: "0.0.0.0",
+        host: "::",
         port: PORT_NUMBER,
     },
     () => {

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -28,7 +28,7 @@ httpServer
         },
     )
     .on("error", () => {
-        // ipv6 only systems might not be able to bind to "::", so we try 0.0.0.0 instead
+        // ipv4 only systems might not be able to bind to "::", so we try 0.0.0.0 instead
         // this is temporary as we plan to bind to localhost in the next major version
         httpServer.listen(
             {

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -13,15 +13,35 @@ const httpServer = express();
 httpServer.use(express.json());
 httpServer.use(express.urlencoded({ extended: true }));
 
-httpServer.listen(
-    {
-        host: "::",
-        port: PORT_NUMBER,
-    },
-    () => {
-        console.log(`Started POT server (v${VERSION}) on port ${PORT_NUMBER}`);
-    },
-);
+httpServer
+    .listen(
+        {
+            host: "::",
+            port: PORT_NUMBER,
+        },
+        (err) => {
+            if (!err) {
+                console.log(
+                    `Started POT server (v${VERSION}) on on address [::]:${PORT_NUMBER}`,
+                );
+            }
+        },
+    )
+    .on("error", () => {
+        // ipv6 only systems might not be able to bind to "::", so we try 0.0.0.0 instead
+        // this is temporary as we plan to bind to localhost in the next major version
+        httpServer.listen(
+            {
+                host: "0.0.0.0",
+                port: PORT_NUMBER,
+            },
+            () => {
+                console.log(
+                    `Started POT server (v${VERSION}) on address 0.0.0.0:${PORT_NUMBER}`,
+                );
+            },
+        );
+    });
 
 const sessionManager = new SessionManager();
 httpServer.post("/get_pot", async (request, response) => {

--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -90,6 +90,7 @@ class ProxySpec {
         if (!proxyUrl) {
             return new Agent({
                 localAddress: sourceAddress,
+                family: this.ipFamily(),
                 rejectUnauthorized: !disableTlsVerification,
             });
         }
@@ -106,11 +107,7 @@ class ProxySpec {
             return new ProxyAgent({
                 getProxyForUrl: () => pxyStr,
                 localAddress: sourceAddress,
-                family: sourceAddress
-                    ? sourceAddress.includes(":")
-                        ? 6
-                        : 4
-                    : undefined,
+                family: this.ipFamily(),
                 rejectUnauthorized: !disableTlsVerification,
             });
         } catch (e) {
@@ -118,6 +115,11 @@ class ProxySpec {
                 cause: e,
             });
         }
+    }
+
+    ipFamily(): number | undefined {
+        if (!this.sourceAddress) return undefined;
+        return this.sourceAddress.includes(":") ? 6 : 4;
     }
 }
 

--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -59,7 +59,7 @@ class ProxySpec {
     constructor({ sourceAddress, disableTlsVerification }: Partial<ProxySpec>) {
         this.sourceAddress = sourceAddress;
         this.disableTlsVerification = disableTlsVerification || false;
-        if (this.sourceAddress) {
+        if (!this.sourceAddress) {
             this.ipFamily = undefined;
         } else {
             this.ipFamily = this.sourceAddress?.includes(":") ? 6 : 4;

--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -55,7 +55,7 @@ class ProxySpec {
     public proxyUrl?: URL;
     public sourceAddress?: string;
     public disableTlsVerification: boolean = false;
-    public ipFamily: number | undefined = 0;
+    public readonly ipFamily?: number;
     constructor({ sourceAddress, disableTlsVerification }: Partial<ProxySpec>) {
         this.sourceAddress = sourceAddress;
         this.disableTlsVerification = disableTlsVerification || false;

--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -106,6 +106,11 @@ class ProxySpec {
             return new ProxyAgent({
                 getProxyForUrl: () => pxyStr,
                 localAddress: sourceAddress,
+                family: sourceAddress
+                    ? sourceAddress.includes(":")
+                        ? 6
+                        : 4
+                    : undefined,
                 rejectUnauthorized: !disableTlsVerification,
             });
         } catch (e) {

--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -55,9 +55,15 @@ class ProxySpec {
     public proxyUrl?: URL;
     public sourceAddress?: string;
     public disableTlsVerification: boolean = false;
+    public ipFamily: number | undefined = 0;
     constructor({ sourceAddress, disableTlsVerification }: Partial<ProxySpec>) {
         this.sourceAddress = sourceAddress;
         this.disableTlsVerification = disableTlsVerification || false;
+        if (this.sourceAddress) {
+            this.ipFamily = undefined;
+        } else {
+            this.ipFamily = this.sourceAddress?.includes(":") ? 6 : 4;
+        }
     }
 
     public get proxy(): string | undefined {
@@ -90,7 +96,7 @@ class ProxySpec {
         if (!proxyUrl) {
             return new Agent({
                 localAddress: sourceAddress,
-                family: this.ipFamily(),
+                family: this.ipFamily,
                 rejectUnauthorized: !disableTlsVerification,
             });
         }
@@ -107,7 +113,7 @@ class ProxySpec {
             return new ProxyAgent({
                 getProxyForUrl: () => pxyStr,
                 localAddress: sourceAddress,
-                family: this.ipFamily(),
+                family: this.ipFamily,
                 rejectUnauthorized: !disableTlsVerification,
             });
         } catch (e) {
@@ -115,11 +121,6 @@ class ProxySpec {
                 cause: e,
             });
         }
-    }
-
-    ipFamily(): number | undefined {
-        if (!this.sourceAddress) return undefined;
-        return this.sourceAddress.includes(":") ? 6 : 4;
     }
 }
 


### PR DESCRIPTION
`::` is ipv6 notation to support routing traffic from all addresses. On dual-stack machines, this works for both ipv6/ipv4 as well. In the rare case that the user's machine doesn't support this, we fallback to 0.0.0.0. 

Also set the IP family.

Should fix #135 and maybe #118, as we are now listening on both ipv6 and ipv4 interfaces. 