### PR TITLE
Fix formatting using autopep8

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,2 @@
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:22-bullseye
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get -y install python3 ffmpeg
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get -y install python3 ffmpeg python3-pip

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -1,1 +1,3 @@
 curl -L https://github.com/yt-dlp/yt-dlp-nightly-builds/releases/latest/download/yt-dlp -o yt-dlp && chmod +x ./yt-dlp && sudo mv yt-dlp /usr/local/bin/yt-dlp
+
+pip install ruff autopep8

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil.py
@@ -63,27 +63,29 @@ class BgUtilPTPBase(PoTokenProvider, abc.ABC):
         if not got_version or _major(got_version) != _major(self.PROVIDER_VERSION):
             self._warn_and_raise(
                 f'Plugin and {name} major versions are mismatched. '
-                f'Update both the plugin and the {name} to the same version to proceed.'
+                f'Update both the plugin and the {name} to the same version to proceed.',
             )
 
     def _get_attestation(self, webpage: str | None):
         if not webpage:
             return None
         raw_challenge_data = self.ie._search_regex(
-            r"""(?sx)window\.ytAtR\s*=\s*(?P<raw_cd>(?P<q>['"])
+            r'''(?sx)window\.ytAtR\s*=\s*(?P<raw_cd>(?P<q>['"])
                 (?:
                     \\.|
                     (?!(?P=q)).
                 )*
-            (?P=q))\s*;""",
+            (?P=q))\s*;''',
             webpage,
             'raw challenge data',
             default=None,
             group='raw_cd',
         )
-        att_txt = traverse_obj(raw_challenge_data, ({js_to_json}, {json.loads}, {json.loads}, 'bgChallenge'))
+        att_txt = traverse_obj(raw_challenge_data, ({js_to_json}, {
+                               json.loads}, {json.loads}, 'bgChallenge'))
         if not att_txt:
-            self.logger.warning('Failed to extract initial attestation from the webpage')
+            self.logger.warning(
+                'Failed to extract initial attestation from the webpage')
             return None
         return att_txt
 

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
@@ -88,7 +88,8 @@ class BgUtilHTTPPTP(BgUtilPTPBase):
                 f'Unknown error reaching GET /ping (caused by {e!r})', raise_from=e)
             return
         else:
-            self._check_version(response.get('version', ''), name='HTTP server')
+            self._check_version(response.get(
+                'version', ''), name='HTTP server')
             self._server_available = True
             return True
         finally:
@@ -108,8 +109,10 @@ class BgUtilHTTPPTP(BgUtilPTPBase):
         # used for CI check
         self.logger.trace('Generating POT via HTTP server')
 
-        disable_innertube = bool(self._configuration_arg('disable_innertube', default=[None])[0])
-        challenge = self._get_attestation(None if disable_innertube else request.video_webpage)
+        disable_innertube = bool(self._configuration_arg(
+            'disable_innertube', default=[None])[0])
+        challenge = self._get_attestation(
+            None if disable_innertube else request.video_webpage)
         # The challenge is falsy when the webpage and the challenge are unavailable
         # In this case, we need to disable /att/get since it's broken for web_music
         if not challenge and request.internal_client_name == 'web_music':


### PR DESCRIPTION
Accidentally formatted code using `ruff format` in last commit, re-formatted with autopep8. We are using autopep8 for formatting, and ruff check for linting. 