### PR TITLE
Fix audit results

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -33,7 +33,7 @@
                 "eslint-plugin-prettier": "^5.5.3",
                 "prettier": "3.6.2",
                 "swc-node": "^1.0.0",
-                "typescript": "^5.8.3",
+                "typescript": "^5.9.3",
                 "typescript-eslint": "^8.38.0"
             }
         },

--- a/server/package.json
+++ b/server/package.json
@@ -43,7 +43,7 @@
         "eslint-plugin-prettier": "^5.5.3",
         "prettier": "3.6.2",
         "swc-node": "^1.0.0",
-        "typescript": "^5.8.3",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.38.0"
     }
 }


### PR DESCRIPTION
The first commit replaced the `github:` access to the `develop` branch.

The second commit pre-resolves the `diff` finding below.

The third commit used: `npm audit fix`

The fourth commit is the full update.

It may be worth replacing `ts-node` with `swc-node` since the former appears to be unmaintained, if it is even being used anymore.

--------

npm audit report

* axios  1.0.0 - 1.11.0
Severity: high
Axios is vulnerable to DoS attack through lack of data size check
https://github.com/advisories/GHSA-4hjh-wcwx-xvwj

* body-parser  2.2.0
Severity: moderate
body-parser is vulnerable to denial of service when url encoding is used
https://github.com/advisories/GHSA-wqch-xfxh-vrr4

* diff  <8.0.3
Severity: low
jsdiff has a Denial of Service vulnerability in parsePatch and applyPatch
https://github.com/advisories/GHSA-73rr-hh4g-fpgx

* js-yaml  4.0.0 - 4.1.0
Severity: moderate
js-yaml has prototype pollution in merge (<<)
https://github.com/advisories/GHSA-mh29-5h37-fv8m

* qs  <6.14.1
Severity: high
qs's arrayLimit bypass in its bracket notation allows DoS via memory exhaustion
https://github.com/advisories/GHSA-6rw7-vpxm-498p

* tar-fs  2.0.0 - 2.1.3
Severity: high
tar-fs has a symlink validation bypass if destination directory is predictable with a specific tarball
https://github.com/advisories/GHSA-vj76-c3g6-qr5v

* undici  <6.23.0
Severity: low
Undici has an unbounded decompression chain in HTTP responses on Node.js Fetch API via Content-Encoding leads to resource exhaustion
https://github.com/advisories/GHSA-g9mf-h72j-4rw9

7 vulnerabilities (2 low, 2 moderate, 3 high)