### PR TITLE
[server] get rid of npm audit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,9 @@ jobs:
         run: autopep8 --diff plugin/
       - name: Install server dependencies
         if: always()
-        run: cd server && npm ci --no-audit --no-fund && npm audit
+        run: |
+          cd server
+          npm ci --no-audit --no-fund
       - name: Server lint check (ESlint)
         if: always()
         run: cd server && npx eslint --max-warnings=0 src/

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,14 +5,12 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 
 RUN --mount=type=cache,target=/home/node/.npm,uid=1000,gid=1000 \
-    npm ci --omit=dev --no-audit --no-fund && \
-    npm audit && npm audit signatures
+    npm ci --omit=dev --no-audit --no-fund
 
 FROM install AS build_node
 
 RUN --mount=type=cache,target=/home/node/.npm,uid=1000,gid=1000 \
-    npm ci --no-audit --no-fund && \
-    npm audit && npm audit signatures
+    npm ci --no-audit --no-fund
 
 COPY types/ types/
 COPY tsconfig.json ./


### PR DESCRIPTION
The server should not be exposed to the internet, therefore fixing audit results is a lower priority, and a vulnerability should not block a PR. We will try to bump the dependencies periodically so severe security issues don't persist.