### PR TITLE
Tag node image as main versioned tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=node,enable={{is_default_branch}}
+            type=raw,value=${{ needs.release.outputs.version }},enable={{is_default_branch}}
             # mark as latest only if built on default branch of repository
             type=raw,value=${{ needs.release.outputs.version }}-node,enable={{is_default_branch}}
             # add the new git tag only if built on default branch of repository


### PR DESCRIPTION
On each release, we push to `latest`, `[version]-deno` and `[version]-node`. Previously, we pushed to `latest` and `[version]`. This causes a gap for those pulling for the `[version`] tag like in #210. 
