### PR TITLE
Bind to localhost

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -233,7 +233,7 @@ jobs:
         run: |
           exit_code=0
           ping() {
-            until curl -o- --silent --fail http://127.0.0.1:${{ env.PORT }}/ping 2>&1; do
+            until curl -o- --silent --fail http://localhost:${{ env.PORT }}/ping 2>&1; do
               sleep ${1:-0.5}
             done
           }
@@ -292,7 +292,7 @@ jobs:
           echo "::endgroup::"
 
           # check that the server is returning a POT
-          pot_response=$(curl -s -X POST "http://127.0.0.1:${{ env.PORT }}/get_pot")
+          pot_response=$(curl -s -X POST "http://localhost:${{ env.PORT }}/get_pot")
           echo "::group::Get pot response from the HTTP server"
           if echo "$pot_response" | jq -e . >/dev/null 2>&1; then
             echo "$pot_response" | jq -C
@@ -312,7 +312,7 @@ jobs:
           # expect this to fail, but just make sure that the plugin is invoked
           {
             server_response=$(./yt-dlp ${{ env.TEST_ARGS }} --extractor-args \
-              "youtubepot-bgutilhttp:base_url=http://127.0.0.1:${{ env.PORT }}" dQw4w9WgXcQ 2>&1)
+              "youtubepot-bgutilhttp:base_url=http://localhost:${{ env.PORT }}" dQw4w9WgXcQ 2>&1)
             ret=$?
           } || true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -274,7 +274,7 @@ jobs:
             esac
             cd ..
           else
-            docker run --name bgutil-provider -d -p ${{ env.PORT }}:4416 \
+            docker run --name bgutil-provider --net=host -d -p ${{ env.PORT }}:4416 \
               brainicism/bgutil-ytdlp-pot-provider:ci-${{ matrix.jsrt }}
           fi
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ deno run --allow-env --allow-net --allow-ffi=. --allow-read=. ../src/main.ts [OP
 
 **Server Command Line Options**
 
+- `-b, --bind <HOST>`: The address to bind the server to. Defaults to `localhost`.
 - `-p, --port <PORT>`: The port on which the server listens.
 
 #### (b) Generation Script Option
@@ -108,7 +109,7 @@ python3 -m pip install -U bgutil-ytdlp-pot-provider
 
 ## Usage
 
-If using option (a) HTTP Server for the provider, and the default IP/port number (http://127.0.0.1:4416), you can use yt-dlp like normal 🙂.
+If using option (a) HTTP Server for the provider, and the default IP/port number (http://localhost:4416), you can use yt-dlp like normal 🙂.
 
 If changing the port or IP used for the provider server, pass it to yt-dlp via `base_url`
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This is a JavaScript HTTP server, on port 4416 by default. You have two options 
 Port 4416 is exposed to the host system by default. Pass `-p 1234:4416` in the docker run options (before the image name) to publish the server to port 1234 on the host system. Replace `[OPTIONS]` with the server command line options (usually this is not needed because you can use docker to publish the server to another port).
 
 ```shell
-docker run --name bgutil-provider -d --init brainicism/bgutil-ytdlp-pot-provider [OPTIONS]
+docker run --name bgutil-provider --net=host -d --init brainicism/bgutil-ytdlp-pot-provider [OPTIONS]
 ```
 
 Our Docker image comes in two flavors: Node.js or Deno. The `:latest` tag defaults to Node.js, but you can specify an alternate version/flavor like so: `brainicism/bgutil-ytdlp-pot-provider:1.3.1-deno`. The `:node` tag also points to the latest Node.js image, and `:deno` points to the latest Deno image.

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
@@ -22,7 +22,7 @@ from yt_dlp_plugins.extractor.getpot_bgutil import BgUtilPTPBase
 @register_provider
 class BgUtilHTTPPTP(BgUtilPTPBase):
     PROVIDER_NAME = 'bgutil:http'
-    DEFAULT_BASE_URL = 'http://127.0.0.1:4416'
+    DEFAULT_BASE_URL = 'http://localhost:4416'
     _GET_SERVER_VSN_TIMEOUT = 5.0
 
     def __init__(self, *args, **kwargs):

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -3,11 +3,15 @@ import { strerror, VERSION } from "./utils.ts";
 import { Command } from "commander";
 import express from "express";
 
-const program = new Command().option("-p, --port <PORT>").parse();
+const program = new Command()
+    .option("-p, --port <PORT>", "Port number to listen on", parseInt, 4416)
+    .option("-b, --bind <HOST>", "Bind address", "localhost")
+    .parse();
 
 const options = program.opts();
 
-const PORT_NUMBER = options.port || 4416;
+const PORT_NUMBER = options.port;
+const BIND_HOST = options.bind;
 
 const httpServer = express();
 httpServer.use(express.json());
@@ -16,42 +20,22 @@ httpServer.use(express.urlencoded({ extended: true }));
 httpServer
     .listen(
         {
-            host: "::",
+            host: BIND_HOST,
             port: PORT_NUMBER,
         },
         (err) => {
             if (err) {
                 console.error(
-                    `Could not listen on [::]:${PORT_NUMBER}, falling back to 0.0.0.0 (Caused by ${strerror(err)})`,
+                    `Could not listen on ${BIND_HOST}:${PORT_NUMBER} (Caused by ${strerror(err)})`,
                 );
+                process.exit(1);
             } else {
                 console.log(
-                    `Started POT server (v${VERSION}) on on address [::]:${PORT_NUMBER}`,
+                    `Started POT server (v${VERSION}) on address ${BIND_HOST}:${PORT_NUMBER}`,
                 );
             }
         },
-    )
-    .on("error", () => {
-        // ipv4 only systems might not be able to bind to "::", so we try 0.0.0.0 instead
-        // this is temporary as we plan to bind to localhost in the next major version
-        httpServer.listen(
-            {
-                host: "0.0.0.0",
-                port: PORT_NUMBER,
-            },
-            (err) => {
-                if (err) {
-                    console.error(
-                        `Could not listen on [::]:${PORT_NUMBER} (Caused by ${strerror(err)})`,
-                    );
-                } else {
-                    console.log(
-                        `Started POT server (v${VERSION}) on address 0.0.0.0:${PORT_NUMBER}`,
-                    );
-                }
-            },
-        );
-    });
+    );
 
 const sessionManager = new SessionManager();
 httpServer.get("/", async (request, response) => {

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -17,25 +17,24 @@ const httpServer = express();
 httpServer.use(express.json());
 httpServer.use(express.urlencoded({ extended: true }));
 
-httpServer
-    .listen(
-        {
-            host: BIND_HOST,
-            port: PORT_NUMBER,
-        },
-        (err) => {
-            if (err) {
-                console.error(
-                    `Could not listen on ${BIND_HOST}:${PORT_NUMBER} (Caused by ${strerror(err)})`,
-                );
-                process.exit(1);
-            } else {
-                console.log(
-                    `Started POT server (v${VERSION}) on address ${BIND_HOST}:${PORT_NUMBER}`,
-                );
-            }
-        },
-    );
+httpServer.listen(
+    {
+        host: BIND_HOST,
+        port: PORT_NUMBER,
+    },
+    (err) => {
+        if (err) {
+            console.error(
+                `Could not listen on ${BIND_HOST}:${PORT_NUMBER} (Caused by ${strerror(err)})`,
+            );
+            process.exit(1);
+        } else {
+            console.log(
+                `Started POT server (v${VERSION}) on address ${BIND_HOST}:${PORT_NUMBER}`,
+            );
+        }
+    },
+);
 
 const sessionManager = new SessionManager();
 httpServer.get("/", async (request, response) => {

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -4,14 +4,14 @@ import { Command } from "commander";
 import express from "express";
 
 const program = new Command()
-    .option("-p, --port <PORT>", "Port number to listen on", parseInt, 4416)
-    .option("-b, --bind <HOST>", "Bind address", "localhost")
+    .option("-p, --port <PORT>", "Port number to listen on")
+    .option("-b, --bind <HOST>", "Bind address")
     .parse();
 
 const options = program.opts();
 
-const PORT_NUMBER = options.port;
-const BIND_HOST = options.bind;
+const PORT_NUMBER = options.port || 4416;
+const BIND_HOST = options.bind || "localhost";
 
 const httpServer = express();
 httpServer.use(express.json());


### PR DESCRIPTION
Listening on all interfaces is potentially dangerous, and this service should only really need loopback only. This is potentially a breaking change and will be a new major version