### PR TITLE
fix: derive server version from package.json and add CI version sync check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
           cd server
           npm ci --no-audit --no-fund
           node scripts/check_lockfiles.ts
+          node scripts/check_versions.ts
       - name: Server lint check (ESlint)
         if: always()
         run: cd server && npx eslint --max-warnings=0 src/

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -40,5 +40,5 @@ RUN deno cache --frozen src/main.ts
 EXPOSE 4416
 ENTRYPOINT [ \
     "/usr/bin/deno", "run", "--allow-env", "--allow-net", \
-    "--allow-ffi=/app/node_modules", "--allow-read=/app/node_modules", \
+    "--allow-ffi=/app/node_modules", "--allow-read=/app/node_modules,/app/package.json", \
     "/app/src/main.ts"]

--- a/server/scripts/check_versions.ts
+++ b/server/scripts/check_versions.ts
@@ -1,0 +1,66 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const serverHome = path.resolve(import.meta.dirname, "..");
+
+let exitCode = 0;
+
+function getVersion(filePath: string, extract: (content: string) => string | null, label: string): string | null {
+    const content = fs.readFileSync(filePath, "utf-8");
+    const version = extract(content);
+    if (!version) {
+        console.error(`Could not extract version from ${label} (${filePath})`);
+        exitCode = 1;
+    }
+    return version;
+}
+
+// 1. plugin/yt_dlp_plugins/extractor/getpot_bgutil.py — __version__
+const pyVersion = getVersion(
+    path.resolve(repoRoot, "plugin/yt_dlp_plugins/extractor/getpot_bgutil.py"),
+    (content) => content.match(/__version__\s*=\s*'([^']+)'/)?.[1] ?? null,
+    "Python plugin __version__",
+);
+
+// 2. server/package.json — version
+const pkgVersion = getVersion(
+    path.resolve(serverHome, "package.json"),
+    (content) => JSON.parse(content).version ?? null,
+    "server/package.json",
+);
+
+// 3. README.md — git clone --single-branch --branch <version>
+const readmeVersion = getVersion(
+    path.resolve(repoRoot, "README.md"),
+    (content) =>
+        content.match(
+            /git clone --single-branch --branch ([^\s]+)/,
+        )?.[1] ?? null,
+    "README.md (branch tag)",
+);
+
+const versions = [
+    { label: "Python plugin (__version__)", version: pyVersion },
+    { label: "server/package.json", version: pkgVersion },
+    { label: "README.md (branch tag)", version: readmeVersion },
+];
+
+console.log("Version sources:");
+for (const { label, version } of versions) {
+    console.log(`  ${label}: ${version ?? "NOT FOUND"}`);
+}
+
+const found = versions.filter((v) => v.version !== null);
+const unique = new Set(found.map((v) => v.version));
+if (unique.size > 1) {
+    console.error("\nVersion mismatch detected!");
+    exitCode = 1;
+} else if (unique.size === 1) {
+    console.log(`\nAll versions match: ${[...unique][0]}`);
+} else {
+    console.error("\nNo versions could be extracted.");
+    exitCode = 1;
+}
+
+process.exit(exitCode);

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,6 +1,14 @@
 import { BGError } from "bgutils-js";
+import * as fs from "node:fs";
+import * as path from "node:path";
 
-export const VERSION = "1.3.1";
+const packageJson = JSON.parse(
+    fs.readFileSync(
+        path.resolve(import.meta.dirname, "..", "package.json"),
+        "utf-8",
+    ),
+);
+export const VERSION: string = packageJson.version;
 
 export function strerror(e: any, update?: boolean): string {
     const msg =


### PR DESCRIPTION
## Summary

Eliminates the hardcoded `VERSION` constant in `utils.ts` and adds a CI check to ensure all version strings stay in sync.

### Problem

The version `1.3.1` appears in 4 separate locations with no automated validation:
- `plugin/yt_dlp_plugins/extractor/getpot_bgutil.py` (`__version__`)
- `server/src/utils.ts` (`VERSION`)
- `server/package.json` (`version`)
- `README.md` (git clone branch tag)

A version bump requires manually updating all 4 files — easy to miss one.

### Changes

**`server/src/utils.ts`** — Replace hardcoded `VERSION = "1.3.1"` with a runtime read from `package.json` using `fs.readFileSync`. This eliminates one duplicate source entirely (3 remaining).

**`server/scripts/check_versions.ts`** (new) — CI validation script that extracts versions from all 3 remaining sources (`package.json`, Python plugin `__version__`, README branch tag) and fails if they do not match. Follows the same pattern as the existing `check_lockfiles.ts`.

**`.github/workflows/test.yml`** — Added `node scripts/check_versions.ts` to the `lint-format` job, runs after the lockfile check.

**`server/Dockerfile`** — Updated Deno entrypoint `--allow-read` to include `/app/package.json` (required for the runtime version read).