### PR TITLE
Fix / server: fix proxy support esp. for use in containers; Fix / README: correct incorrect statement about port publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,14 @@ This is a JavaScript HTTP server, on port 4416 by default. You have two options 
 
 **Docker:**
 
-Port 4416 is exposed to the host system by default. Pass `-p 1234:4416` in the docker run options (before the image name) to publish the server to port 1234 on the host system. Replace `[OPTIONS]` with the server command line options (usually this is not needed because you can use docker to publish the server to another port).
-
 ```shell
-docker run --name bgutil-provider -d --init brainicism/bgutil-ytdlp-pot-provider [OPTIONS]
+docker run --name bgutil-provider -p 4416:4416 -d --init brainicism/bgutil-ytdlp-pot-provider
 ```
 
 Our Docker image comes in two flavors: Node.js or Deno. The `:latest` tag defaults to Node.js, but you can specify an alternate version/flavor like so: `brainicism/bgutil-ytdlp-pot-provider:1.3.1-deno`. The `:node` tag also points to the latest Node.js image, and `:deno` points to the latest Deno image.
 
 > [!IMPORTANT]
-> Note that the docker container's network is isolated from your local network by default. If you are using a local proxy server, it will not be accessible from within the container unless you pass `--net=host` as well.
+> Note that the container's network is isolated from your local network by default. If you are using a local proxy server, you need to pass `-e ALL_PROXY=http|socks5://host.containers.internal:PROXY_PORT` to Docker (i.e. before `brainicism/bgutil-ytdlp-pot-provider`) and `--local-proxy` to this program (i.e. after `brainicism/bgutil-ytdlp-pot-provider`).
 
 **Native:**
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ docker run --name bgutil-provider -p 4416:4416 -d --init brainicism/bgutil-ytdlp
 Our Docker image comes in two flavors: Node.js or Deno. The `:latest` tag defaults to Node.js, but you can specify an alternate version/flavor like so: `brainicism/bgutil-ytdlp-pot-provider:1.3.1-deno`. The `:node` tag also points to the latest Node.js image, and `:deno` points to the latest Deno image.
 
 > [!IMPORTANT]
-> Note that the container's network is isolated from your local network by default. If you are using a local proxy server, you need to pass `-e ALL_PROXY=http|socks5://host.containers.internal:PROXY_PORT` to Docker (i.e. before `brainicism/bgutil-ytdlp-pot-provider`) and `--local-proxy` to this program (i.e. after `brainicism/bgutil-ytdlp-pot-provider`).
+> Note that the container's network is isolated from your local network by default. If you are using a local proxy server, you need to pass `--extractor-args "youtubepot-bgutilhttp:proxy=socks5h://host.containers.internal:[PROXY_PORT]"` to yt-dlp.
 
 **Native:**
 

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
@@ -31,6 +31,15 @@ class BgUtilHTTPPTP(BgUtilPTPBase):
         self._server_available = True
 
     @functools.cached_property
+    def _manual_proxy(self) -> str | False | None:
+        proxy = self._configuration_arg('proxy', default=[None])[0]
+
+        if proxy == '' or proxy == 'none':
+            return False
+
+        return proxy
+
+    @functools.cached_property
     def _base_url(self):
         base_url = self._configuration_arg('base_url', default=[None])[0]
 
@@ -119,6 +128,8 @@ class BgUtilHTTPPTP(BgUtilPTPBase):
                 'a PO Token cannot be generated because InnerTube challenges '
                 'are currently broken for the web_music client. ')
 
+        proxy = request.request_proxy if self._manual_proxy is None else self._manual_proxy
+
         try:
             response = self._request_webpage(
                 request=Request(
@@ -127,7 +138,7 @@ class BgUtilHTTPPTP(BgUtilPTPBase):
                         'challenge': challenge,
                         'content_binding': get_webpo_content_binding(request)[0],
                         'disable_tls_verification': not request.request_verify_tls,
-                        'proxy': request.request_proxy,
+                        'proxy': proxy,
                         'innertube_context': request.innertube_context,
                         'source_address': request.request_source_address,
                     }).encode(), headers={'Content-Type': 'application/json'},

--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py
@@ -149,6 +149,15 @@ class BgUtilScriptPTPBase(BgUtilPTPBase, abc.ABC):
             return False
 
     @functools.cached_property
+    def _manual_proxy(self) -> str | False | None:
+        proxy = self._script_config_arg('proxy')
+
+        if proxy == '' or proxy == 'none':
+            return False
+
+        return proxy
+
+    @functools.cached_property
     def _script_path(self) -> str:
         return self._script_path_impl()
 
@@ -222,8 +231,8 @@ class BgUtilScriptPTPBase(BgUtilPTPBase, abc.ABC):
             f'Generating POT via script: {self._script_path}')
 
         command_args = [self._jsrt_path, *self._jsrt_args(), self._script_path]
-        if proxy := request.request_proxy:
-            command_args.extend(['-p', proxy])
+        proxy = (request.request_proxy if self._manual_proxy is None else self._manual_proxy) or ''
+        command_args.extend(['-p', proxy])
         command_args.extend(['-c', get_webpo_content_binding(request)[0]])
         command_args.extend(['--innertube-context', json.dumps(request.innertube_context)])
         if request.bypass_cache:

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -7,7 +7,7 @@ const program = new Command()
     .option("-p, --port <PORT>")
     .option(
         "-P, --local-proxy",
-        "Use proxy specified in local env vars, instead of that passed by the client"
+        "Use proxy locally specified in env vars, overriding that passed by the client",
     )
     .parse();
 
@@ -83,8 +83,13 @@ httpServer.post("/get_pot", async (request, response) => {
             error: "disable_innertube is deprecated because the /Create endpoint doesn't work anymore",
         });
 
+    const proxy: string = options.localProxy
+        ? process.env.HTTPS_PROXY ||
+          process.env.HTTP_PROXY ||
+          process.env.ALL_PROXY ||
+          ""
+        : body.proxy || "";
     const contentBinding: string | undefined = body.content_binding;
-    const proxy: string | null = options.localProxy ? null : body.proxy;
     const bypassCache: boolean = body.bypass_cache || false;
     const sourceAddress: string | undefined = body.source_address;
     const disableTlsVerification: boolean =

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -3,7 +3,13 @@ import { strerror, VERSION } from "./utils.ts";
 import { Command } from "commander";
 import express from "express";
 
-const program = new Command().option("-p, --port <PORT>").parse();
+const program = new Command()
+    .option("-p, --port <PORT>")
+    .option(
+        "-P, --local-proxy",
+        "Use proxy specified in local env vars, instead of that passed by the client"
+    )
+    .parse();
 
 const options = program.opts();
 
@@ -78,7 +84,7 @@ httpServer.post("/get_pot", async (request, response) => {
         });
 
     const contentBinding: string | undefined = body.content_binding;
-    const proxy: string = body.proxy;
+    const proxy: string | null = options.localProxy ? null : body.proxy;
     const bypassCache: boolean = body.bypass_cache || false;
     const sourceAddress: string | undefined = body.source_address;
     const disableTlsVerification: boolean =

--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -422,6 +422,7 @@ export class SessionManager {
                         headers: options?.headers,
                         params: options?.params,
                         httpsAgent: proxySpec.asDispatcher(logger),
+                        proxy: false, // Axios' built-in proxy support is broken for all cases except http-over-http. Here proxy-agent is used.
                     };
                     const response = await (method === "GET"
                         ? axios.get(url, axiosOpt)
@@ -452,7 +453,7 @@ export class SessionManager {
 
     async generatePoToken(
         contentBinding: string | undefined,
-        proxy: string = "",
+        proxy: string | null = "",
         bypassCache = false,
         sourceAddress: string | undefined = undefined,
         disableTlsVerification: boolean = false,

--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -453,7 +453,7 @@ export class SessionManager {
 
     async generatePoToken(
         contentBinding: string | undefined,
-        proxy: string | null = "",
+        proxy: string = "",
         bypassCache = false,
         sourceAddress: string | undefined = undefined,
         disableTlsVerification: boolean = false,
@@ -468,11 +468,6 @@ export class SessionManager {
         });
         if (proxy) {
             pxySpec.proxy = proxy;
-        } else {
-            pxySpec.proxy =
-                process.env.HTTPS_PROXY ||
-                process.env.HTTP_PROXY ||
-                process.env.ALL_PROXY;
         }
 
         const cacheSpec = new CacheSpec(


### PR DESCRIPTION
For the server, fixed proxy support for use in cases:
- where proxy env vars are set (currently Axios would try to use its native support which is broken for all cases except http-over-http on the top of passed-in `proxy-agent` `httpsAgent`)
- or where proxy different from that passed by the client is needed, such as for use inside containers (e.g., http://host.containers.internal:1080 instead of http://127.0.0.1:1080)

To the plugin:
- added --extractor-args "youtubepot-bgutilhttp:proxy=none|[some-proxy-url]" and --extractor-args "youtubepot-bgutilscript:proxy=none|[some-proxy-url]" for manual proxy specification

For README:
- Docker command-line and port publishing: corrected to that Docker does not automatically publish exposed ports. Needs to specify `-p 4416:4416`
- Proxy: local proxy can use `host.containers.internal` to reach the host.