### PR TITLE
Ignore deprecated disable_innertube arg

### DIFF
--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_http.py
@@ -107,8 +107,9 @@ class BgUtilHTTPPTP(BgUtilPTPBase):
         self.logger.trace('Generating POT via HTTP server')
 
         if self._configuration_arg('disable_innertube', default=[None])[0] is not None:
-            self._warn_and_raise(
-                "'youtubepot-bgutilhttp:disable_innertube' extractor arg is deprecated")
+            self.logger.warning(
+                "'youtubepot-bgutilhttp:disable_innertube' extractor arg is deprecated and will be ignored",
+                once=True)
 
         challenge = self._get_attestation(request.video_webpage)
         # The challenge is falsy when the webpage and the challenge are unavailable


### PR DESCRIPTION
### This changes handling of the deprecated youtubepot-bgutilhttp:disable_innertube extractor arg from hard rejection to warning-only behavior.

**Problem:**
The HTTP plugin currently rejects requests when callers still provide the deprecated disable_innertube arg. That makes upgrades unnecessarily disruptive for existing integrations that still send the flag, even though it is no longer needed.

**Change:**

- keep logging a warning
- ignore the deprecated arg
- continue normal token generation instead of rejecting the request

**Why:**
This is a compatibility improvement. Existing clients get a safer upgrade path, and the deprecated flag behaves like an ignored no-op rather than a request-blocking error.