### PR TITLE
Fix getpot_bgutil_script.py from hanging and timing out

### DIFF
--- a/plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py
+++ b/plugin/yt_dlp_plugins/extractor/getpot_bgutil_script.py
@@ -307,7 +307,7 @@ class BgUtilScriptDenoPTP(BgUtilScriptPTPBase):
             return ','.join(s.replace(',', ',,') for s in strs)
         node_mods_path = os.path.join(self._server_home, 'node_modules')
         return (
-            'run', '--allow-env', '--allow-net',
+            'run', '--allow-sys=osRelease', '--allow-env', '--allow-net',
             f'--allow-ffi={escpath(node_mods_path)}',
             f'--allow-write={escpath(self._script_cache_dir)}',
             f'--allow-read={escpath(self._script_cache_dir, node_mods_path)}',


### PR DESCRIPTION
Script now does not hang when deno prompts for permission to use osRelease and prevents yt-dlp from being rendered unusable if that script is ran at startup.