### PR TITLE
[ci] Avoid SIGPIPE flake in script method test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,8 +162,10 @@ jobs:
             [ "$exit_code" -eq 0 ] && exit_code=1
           fi
 
-          pot_response=$(echo "$script_response" | \
-            grep -A1 -m1 '\[youtube\] \[pot:bgutil:script-${{ matrix.jsrt }}\] TRACE: JSON response:' | \
+          # here-string instead of `echo |` so that grep -m1 exiting early
+          # can't SIGPIPE the producer and fail the step under pipefail
+          pot_response=$(grep -A1 -m1 '\[youtube\] \[pot:bgutil:script-${{ matrix.jsrt }}\] TRACE: JSON response:' \
+            <<< "$script_response" | \
             tail -n1 | \
             jq -r '.poToken')
           echo "POT: $pot_response"


### PR DESCRIPTION
Seen on #249's first run (`Test plugin (script method) (deno)`): the POT was generated fine, but the step ended with

```
line 57: echo: write error: Broken pipe
##[error]Process completed with exit code 1.
```

`echo "$script_response" | grep -A1 -m1 ... | tail -n1 | jq` races: `grep -m1` exits on its first match, `echo` is still writing the large `-vF` output and gets SIGPIPE, and under GitHub's `bash -e -o pipefail` that fails the assignment. Feed `grep` with a here-string so there's no producer process to kill. The equivalent server-method pipeline is already guarded with `{ ... } || true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qw55QSQL3caKC8GBohwcUQ
