### PR TITLE
[server] disable axios' builtin proxy to fix HTTPS_PROXY for node<22.21 or 24.5

### DIFF
--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -495,6 +495,7 @@ export class SessionManager {
                         headers: options?.headers,
                         params: options?.params,
                         httpsAgent: proxySpec.asDispatcher(logger),
+                        proxy: false,
                     };
                     const response = await (method === "GET"
                         ? axios.get(url, axiosOpt)


### PR DESCRIPTION
Fixes #239 