### PR TITLE
[server] Bind HTTP server to localhost by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,7 +277,8 @@ jobs:
             cd ..
           else
             docker run --name bgutil-provider -d -p ${{ env.PORT }}:4416 \
-              brainicism/bgutil-ytdlp-pot-provider:ci-${{ matrix.jsrt }}
+              brainicism/bgutil-ytdlp-pot-provider:ci-${{ matrix.jsrt }} \
+              --host 0.0.0.0
           fi
 
           echo "Waiting for server to be up..."

--- a/README.md
+++ b/README.md
@@ -48,14 +48,15 @@ deno install --allow-scripts=npm:canvas --frozen
 
 #### (a) HTTP Server Option
 
-This is a JavaScript HTTP server, on port 4416 by default. You have two options for running it: as a prebuilt Docker image, or manually as a JavaScript application.
+This is a JavaScript HTTP server, on port 4416 by default, bound to localhost only (`127.0.0.1` / `::1`). You have two options for running it: as a prebuilt Docker image, or manually as a JavaScript application.
 
 **Docker:**
 
-Port 4416 is exposed to the host system by default. Pass `-p 1234:4416` in the docker run options (before the image name) to publish the server to port 1234 on the host system. Replace `[OPTIONS]` with the server command line options (usually this is not needed because you can use docker to publish the server to another port).
+Publish the port and opt into a non-localhost bind:
 
 ```shell
-docker run --name bgutil-provider -d --init brainicism/bgutil-ytdlp-pot-provider [OPTIONS]
+docker run --name bgutil-provider -d --init -p 4416:4416 \
+  brainicism/bgutil-ytdlp-pot-provider --host 0.0.0.0
 ```
 
 Our Docker image comes in two flavors: Node.js or Deno. The `:latest` tag defaults to Node.js, but you can specify an alternate version/flavor like so: `brainicism/bgutil-ytdlp-pot-provider:1.3.2-deno`. The `:node` tag also points to the latest Node.js image, and `:deno` points to the latest Deno image.
@@ -83,6 +84,7 @@ deno run --allow-env --allow-net --allow-ffi=. --allow-read=. ../src/main.ts [OP
 **Server Command Line Options**
 
 - `-p, --port <PORT>`: The port on which the server listens.
+- `-H, --host <HOST>`: Host/IP to listen on. Repeat it or separate values with commas to bind multiple addresses. Defaults to localhost only (`127.0.0.1` and `::1`).
 
 #### (b) Generation Script Option
 
@@ -110,7 +112,7 @@ python3 -m pip install -U bgutil-ytdlp-pot-provider
 
 If using option (a) HTTP Server for the provider, and the default IP/port number (http://127.0.0.1:4416), you can use yt-dlp like normal 🙂.
 
-If changing the port or IP used for the provider server, pass it to yt-dlp via `base_url`
+If the provider server is reachable at a different URL, pass it to yt-dlp via `base_url`:
 
 ```shell
 --extractor-args "youtubepot-bgutilhttp:base_url=http://127.0.0.1:8080"

--- a/server/README.md
+++ b/server/README.md
@@ -7,6 +7,11 @@ If you are interested in using the script/server standalone for generating your 
 
 # Server
 
+**Options**
+
+- `-p, --port <PORT>`: The port on which the server listens.
+- `-H, --host <HOST>`: Host/IP to listen on. Repeat it or separate values with commas to bind multiple addresses. Defaults to localhost only (`127.0.0.1` and `::1`).
+
 **Endpoints**
 
 - **POST /get_pot**: Generate a new POT.

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -5,24 +5,48 @@ import express from "express";
 import http from "node:http";
 import net from "node:net";
 
-const program = new Command().option("-p, --port <PORT>").parse();
+function collectHosts(host: string, previous: string[]) {
+    previous.push(
+        ...host
+            .split(",")
+            .map((entry) => entry.trim())
+            .filter(Boolean),
+    );
+    return previous;
+}
 
-const options = program.opts();
+const program = new Command()
+    .option("-p, --port <PORT>")
+    .option(
+        "-H, --host <HOST>",
+        "Host/IP to listen on; repeat or separate with commas to bind multiple addresses",
+        collectHosts,
+        [],
+    )
+    .parse();
 
-const PORT_NUMBER = options.port || 4416;
+const cliOptions = program.opts();
+
+const PORT_NUMBER = cliOptions.port || 4416;
 
 const httpServer = express();
 httpServer.use(express.json());
 
-// Like nginx (`listen [::]:80 ipv6only=on; listen 80;`) and Redis (`bind * -::*`),
-// bind the IPv6 and IPv4 wildcards as two separate sockets, with the IPv6 one
-// restricted to IPv6 so the two never overlap. Every address is optional: a
-// failure is logged, and startup only aborts if nothing could be bound.
-// NOTE: this is temporary as we plan to bind to localhost in the next major version
+// Bind the IPv6 and IPv4 localhost addresses as separate sockets, with the
+// IPv6 one restricted to IPv6 so the two never overlap. Every address is
+// optional: a failure is logged, and startup only aborts if nothing could be
+// bound.
 const LISTEN_ADDRESSES: (net.ListenOptions & { host: string })[] = [
-    { host: "::", ipv6Only: true },
-    { host: "0.0.0.0" },
+    { host: "::1", ipv6Only: true },
+    { host: "127.0.0.1" },
 ];
+
+function getListenAddresses(hosts: string[]) {
+    if (hosts.length === 0) return LISTEN_ADDRESSES;
+    return hosts.map((host) =>
+        host.includes(":") ? { host, ipv6Only: true } : { host },
+    );
+}
 
 function formatAddress(host: string) {
     return `${host.includes(":") ? `[${host}]` : host}:${PORT_NUMBER}`;
@@ -41,14 +65,14 @@ function listen(options: net.ListenOptions): Promise<http.Server> {
 
 async function startServer() {
     const bound: string[] = [];
-    for (const options of LISTEN_ADDRESSES) {
-        const address = formatAddress(options.host);
+    for (const listenOptions of getListenAddresses(cliOptions.host)) {
+        const address = formatAddress(listenOptions.host);
         try {
-            await listen(options);
+            await listen(listenOptions);
             bound.push(address);
         } catch (err) {
             // Deno ignores `ipv6Only` (and on Windows leaves the OS default of
-            // IPv6-only, #244), so with a dual-stack "::" socket the 0.0.0.0
+            // IPv6-only, #244), so with a dual-stack "::1" socket the 127.0.0.1
             // bind collides with it. That only means IPv4 is already served.
             if (err?.code === "EADDRINUSE" && bound.length > 0) continue;
             console.error(


### PR DESCRIPTION
Summary
- Bind the HTTP server to localhost by default (`127.0.0.1` / `::1`).
- Add `--host` / `-H` for explicit non-localhost binds.
- Update Docker and server docs for the new default.

Breaking change
- Docker and remote-access setups must pass `--host 0.0.0.0` or another explicit host.

Testing
- `npm run lint`
- `npx tsc --noEmit`