### PR TITLE
[server] Reject browser-originated requests

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -12,6 +12,17 @@ const options = program.opts();
 const PORT_NUMBER = options.port || 4416;
 
 const httpServer = express();
+httpServer.use((request, response, next) => {
+    if (
+        request.get("Origin") ||
+        request.get("Sec-Fetch-Site")?.toLowerCase() === "cross-site"
+    ) {
+        return response.status(403).send({
+            error: "Browser-originated requests are not allowed",
+        });
+    }
+    next();
+});
 httpServer.use(express.json());
 
 // Like nginx (`listen [::]:80 ipv6only=on; listen 80;`) and Redis (`bind * -::*`),


### PR DESCRIPTION
## Summary

- Reject requests carrying an Origin header.
- Reject requests marked Sec-Fetch-Site: cross-site.
- Preserve access for yt-dlp and other non-browser local clients.

## Why

This prevents ordinary browser pages from driving the unauthenticated localhost service. Origin and Fetch Metadata headers are controlled by the browser and cannot be changed by normal page JavaScript.

## Validation

- [x] ESLint
- [x] Prettier
- [x] TypeScript typecheck
- [x] Normal request returns 200
- [x] Origin and cross-site requests return 403