### PR TITLE
[server] Require application/json for /get_pot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,8 +293,18 @@ jobs:
           fi
           echo "::endgroup::"
 
-          # check that the server is returning a POT
-          pot_response=$(curl -s -X POST "http://127.0.0.1:${{ env.PORT }}/get_pot")
+          # check that non-JSON requests are rejected
+          non_json_status=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+            "http://127.0.0.1:${{ env.PORT }}/get_pot")
+          if [ "$non_json_status" != "415" ]; then
+            echo "::error title=Non-JSON request was not rejected,file=server/src/main.ts::\
+          Expected HTTP 415, received HTTP $non_json_status."
+            exit 1
+          fi
+
+          # check that the server is returning a POT for a JSON request
+          pot_response=$(curl -s -X POST -H 'Content-Type: application/json' \
+            --data '{}' "http://127.0.0.1:${{ env.PORT }}/get_pot")
           echo "::group::Get pot response from the HTTP server"
           if echo "$pot_response" | jq -e . >/dev/null 2>&1; then
             echo "$pot_response" | jq -C

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -77,6 +77,12 @@ httpServer.get("/", async (request, response) => {
 });
 
 httpServer.post("/get_pot", async (request, response) => {
+    if (!request.is("application/json")) {
+        return response.status(415).send({
+            error: "Content-Type must be application/json",
+        });
+    }
+
     const body = request.body || {};
     if (body.data_sync_id)
         return response.status(400).send({


### PR DESCRIPTION
## Summary

Require application/json for POST /get_pot. Requests using a form, text, or missing content type now return HTTP 415 before token generation begins.

## Validation

- [x] ESLint
- [x] Prettier
- [x] TypeScript typecheck
- [x] Non-JSON request returns 415
- [x] JSON request reaches normal route validation