### PR TITLE
[server] Block PAC proxy schemes

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,4 +1,4 @@
-import { SessionManager } from "./session_manager.ts";
+import { InvalidProxyError, SessionManager } from "./session_manager.ts";
 import { strerror, VERSION } from "./utils.ts";
 import { Command } from "commander";
 import express from "express";
@@ -112,8 +112,10 @@ httpServer.post("/get_pot", async (request, response) => {
         response.send(sessionData);
     } catch (e) {
         const msg = strerror(e, /*update=*/ true);
-        console.error(e.stack);
-        response.status(500).send({ error: msg });
+        if (!(e instanceof InvalidProxyError)) console.error(e.stack);
+        response.status(e instanceof InvalidProxyError ? 400 : 500).send({
+            error: msg,
+        });
     }
 });
 

--- a/server/src/session_manager.ts
+++ b/server/src/session_manager.ts
@@ -27,6 +27,23 @@ interface YoutubeSessionData {
     expiresAt: Date;
 }
 
+const SUPPORTED_PROXY_PROTOCOLS = new Set([
+    "http:",
+    "https:",
+    "socks:",
+    "socks4:",
+    "socks4a:",
+    "socks5:",
+    "socks5h:",
+]);
+
+export class InvalidProxyError extends Error {
+    constructor(message: string, options?: ErrorOptions) {
+        super(message, options);
+        this.name = "InvalidProxyError";
+    }
+}
+
 export interface YoutubeSessionDataCaches {
     [contentBinding: string]: YoutubeSessionData;
 }
@@ -79,18 +96,26 @@ class ProxySpec {
     public set proxy(newProxy: string | undefined) {
         if (newProxy) {
             // Normalize and sanitize the proxy URL
+            let proxyUrl: URL;
             try {
-                this.proxyUrl = new URL(newProxy);
+                proxyUrl = new URL(newProxy);
             } catch {
                 newProxy = `http://${newProxy}`;
                 try {
-                    this.proxyUrl = new URL(newProxy);
+                    proxyUrl = new URL(newProxy);
                 } catch (e) {
-                    throw new Error(`Invalid proxy URL: ${newProxy}`, {
-                        cause: e,
-                    });
+                    throw new InvalidProxyError(
+                        `Invalid proxy URL: ${newProxy}`,
+                        { cause: e },
+                    );
                 }
             }
+            if (!SUPPORTED_PROXY_PROTOCOLS.has(proxyUrl.protocol)) {
+                throw new InvalidProxyError(
+                    `Unsupported proxy protocol: ${proxyUrl.protocol}`,
+                );
+            }
+            this.proxyUrl = proxyUrl;
         }
     }
 


### PR DESCRIPTION
## Summary

- Allow HTTP and HTTPS proxy URLs.
- Allow supported SOCKS proxy URLs.
- Reject PAC file, network, and data URLs with HTTP 400.

## Validation

- [x] ESLint
- [x] Prettier
- [x] TypeScript typecheck
- [x] pac+file request returns 400 before proxy-agent is invoked