### PR TITLE
[docker] Use loopback for published provider port

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -276,9 +276,9 @@ jobs:
             esac
             cd ..
           else
-            docker run --name bgutil-provider -d -p ${{ env.PORT }}:4416 \
-              brainicism/bgutil-ytdlp-pot-provider:ci-${{ matrix.jsrt }} \
-              --host 0.0.0.0
+            docker run --name bgutil-provider -d \
+              -p 127.0.0.1:${{ env.PORT }}:4416 \
+              brainicism/bgutil-ytdlp-pot-provider:ci-${{ matrix.jsrt }}
           fi
 
           echo "Waiting for server to be up..."

--- a/README.md
+++ b/README.md
@@ -48,16 +48,19 @@ deno install --allow-scripts=npm:canvas --frozen
 
 #### (a) HTTP Server Option
 
-This is a JavaScript HTTP server, on port 4416 by default, bound to localhost only (`127.0.0.1` / `::1`). You have two options for running it: as a prebuilt Docker image, or manually as a JavaScript application.
+This is a JavaScript HTTP server on port 4416 by default. When run natively, it binds to localhost only (`127.0.0.1` / `::1`). You have two options for running it: as a prebuilt Docker image, or manually as a JavaScript application.
 
 **Docker:**
 
-Publish the port and opt into a non-localhost bind:
+The Docker image binds the server to all interfaces inside the container so that port forwarding works. Publish it only to the host's IPv4 loopback interface:
 
 ```shell
-docker run --name bgutil-provider -d --init -p 4416:4416 \
-  brainicism/bgutil-ytdlp-pot-provider --host 0.0.0.0
+docker run --name bgutil-provider -d --init \
+  -p 127.0.0.1:4416:4416 brainicism/bgutil-ytdlp-pot-provider
 ```
+
+> [!WARNING]
+> Omitting `127.0.0.1` from the port mapping publishes the server on all host interfaces by default. This may allow untrusted local or external clients to access the unauthenticated server, generate tokens, consume system and network resources and potentially perform RCE.
 
 Our Docker image comes in two flavors: Node.js or Deno. The `:latest` tag defaults to Node.js, but you can specify an alternate version/flavor like so: `brainicism/bgutil-ytdlp-pot-provider:1.3.2-deno`. The `:node` tag also points to the latest Node.js image, and `:deno` points to the latest Deno image.
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,6 +23,7 @@ COPY --from=build_node /app/build /app/build
 
 EXPOSE 4416
 ENTRYPOINT ["/usr/local/bin/node", "build/main.js"]
+CMD ["--host", "0.0.0.0"]
 
 FROM denoland/deno:debian-2.9.5 AS server_deno
 USER deno
@@ -42,3 +43,4 @@ ENTRYPOINT [ \
     "/usr/bin/deno", "run", "--allow-env", "--allow-net", \
     "--allow-ffi=/app/node_modules", "--allow-read=/app/node_modules", \
     "/app/src/main.ts"]
+CMD ["--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary

- default both Docker image variants to listening on 0.0.0.0 inside the container
- publish the documented and CI host port on 127.0.0.1 only
- warn that omitting the host IP exposes the unauthenticated provider on all host interfaces

## Testing

- git diff --check
- docker buildx build --check --file server/Dockerfile server
- built the server_node target
- started the image with a loopback-only ephemeral host port and verified /ping, the internal 0.0.0.0 bind, and the 127.0.0.1 Docker mapping

## Docker argument behavior

The image default is supplied through CMD, so explicit arguments passed after the image name replace the complete default. An explicit --host therefore overrides it; callers passing only another option such as --port must also include --host 0.0.0.0.